### PR TITLE
Add right-click context menus across the UI

### DIFF
--- a/desktop/src/components/TabWindowManager/index.tsx
+++ b/desktop/src/components/TabWindowManager/index.tsx
@@ -2,14 +2,17 @@ import React, { Component } from 'react';
 import { Layout, Model, TabNode, IJsonModel, Actions, DockLocation } from 'flexlayout-react';
 import 'flexlayout-react/style/light.css';
 import { TreeIcon } from '../WorkSpace/TreeIcon';
+import { ContextMenu } from 'ssui_components';
 import "@blueprintjs/core/lib/css/blueprint.css";
 import "@blueprintjs/icons/lib/css/blueprint-icons.css";
+import i18n from '../../i18n/i18n';
 import styles from "./style.module.css";
 
 
 interface State {
   model: Model;
   activeTabId?: string;
+  tabContextMenu: { x: number; y: number; tabId: string } | null;
 }
 
 export class TabWindowManager extends Component<{}, State> {
@@ -38,7 +41,8 @@ export class TabWindowManager extends Component<{}, State> {
     };
 
     this.state = {
-      model: Model.fromJson(json)
+      model: Model.fromJson(json),
+      tabContextMenu: null
     };
   }
 
@@ -56,6 +60,49 @@ export class TabWindowManager extends Component<{}, State> {
       const model = prevState.model;
       model.doAction(Actions.deleteTab(tabId));
       return { model };
+    });
+  };
+
+  handleTabContextMenu = (e: React.MouseEvent, tabId: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    this.setState({
+      tabContextMenu: { x: e.clientX, y: e.clientY, tabId }
+    });
+  };
+
+  closeContextMenu = () => {
+    this.setState({ tabContextMenu: null });
+  };
+
+  closeOtherTabs = (tabId: string) => {
+    this.setState(prevState => {
+      const model = prevState.model;
+      const node = model.getNodeById(tabId);
+      const parent = node?.getParent();
+      if (!parent) {
+        return { ...prevState, model };
+      }
+      parent.getChildren().forEach(child => {
+        if (child.getId() !== tabId) {
+          model.doAction(Actions.deleteTab(child.getId()));
+        }
+      });
+      return { ...prevState, model };
+    });
+  };
+
+  closeAllTabs = () => {
+    this.setState(prevState => {
+      const model = prevState.model;
+      const tabIds: string[] = [];
+      model.visitNodes(node => {
+        if (node.getType() === 'tab') {
+          tabIds.push(node.getId());
+        }
+      });
+      tabIds.forEach(tabId => model.doAction(Actions.deleteTab(tabId)));
+      return { ...prevState, model };
     });
   };
 
@@ -150,25 +197,55 @@ export class TabWindowManager extends Component<{}, State> {
   // 渲染标签标题
   renderTabTitle = (node: TabNode) => {
     return (
-      <div className={styles.tabTitle}>
+      <div
+        className={styles.tabTitle}
+        onContextMenu={(e) => this.handleTabContextMenu(e, node.getId())}
+      >
         <span><span className={styles.treeIcon}>{TreeIcon(node.getName())}</span>{node.getName()}</span>
       </div>
     );
   };
 
   render() {
+    const { tabContextMenu } = this.state;
     return (
-      <Layout
-        model={this.state.model}
-        factory={this.factory}
-        onModelChange={(model) => this.setState({ model })}
-        onTabSetPlaceHolder={() => {
-          return <div className={styles.noTabsContainer}>Open a file to start browsing</div>;
-        }}
-        onRenderTab={(node, renderValues) => {
-          renderValues.content = this.renderTabTitle(node);
-        }}
-      />
+      <React.Fragment>
+        <Layout
+          model={this.state.model}
+          factory={this.factory}
+          onModelChange={(model) => this.setState({ model })}
+          onTabSetPlaceHolder={() => {
+            return <div className={styles.noTabsContainer}>Open a file to start browsing</div>;
+          }}
+          onRenderTab={(node, renderValues) => {
+            renderValues.content = this.renderTabTitle(node);
+          }}
+        />
+        {tabContextMenu && (
+          <ContextMenu
+            x={tabContextMenu.x}
+            y={tabContextMenu.y}
+            items={[
+              {
+                label: i18n.t('tabs.close'),
+                icon: 'cross',
+                onClick: () => this.handleTabClose(tabContextMenu.tabId)
+              },
+              {
+                label: i18n.t('tabs.closeOthers'),
+                icon: 'layout-auto',
+                onClick: () => this.closeOtherTabs(tabContextMenu.tabId)
+              },
+              {
+                label: i18n.t('tabs.closeAll'),
+                icon: 'trash',
+                onClick: () => this.closeAllTabs()
+              }
+            ]}
+            onClose={this.closeContextMenu}
+          />
+        )}
+      </React.Fragment>
     );
   }
 

--- a/desktop/src/components/TabWindowManager/style.module.css
+++ b/desktop/src/components/TabWindowManager/style.module.css
@@ -24,3 +24,12 @@
         height: 18px;
     }
 }
+
+.tabTitle {
+    cursor: context-menu;
+    user-select: none;
+    padding: 0 4px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}

--- a/desktop/src/components/WorkSpace/index.tsx
+++ b/desktop/src/components/WorkSpace/index.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useState,useRef} from 'react';
 import {Button, Tree, Icon, Popover, Menu, MenuItem} from "@blueprintjs/core";
+import { ContextMenu, ContextMenuItem } from 'ssui_components';
 import { TauriFilesystemProvider, IFilesystemProvider, ExtendTreeNodeInfo } from '../../providers/FilesystemProvider';
 import styles from './style.module.css'
 import {TreeIcon} from "./TreeIcon.tsx";
@@ -20,8 +21,15 @@ interface WorkSpaceProps {
 export const WorkSpace = (props: WorkSpaceProps) => {
     const { currentWorkspace, onOpenWorkspace, onSelectWorkflow } = props
     const [ fileTree, setFileTree ] = useState<ExtendTreeNodeInfo>()
+    const [ contextMenu, setContextMenu ] = useState<{ x: number; y: number; node: ExtendTreeNodeInfo } | null>(null)
     const filesystemProvider = useRef<IFilesystemProvider>(props.filesystemProvider || new TauriFilesystemProvider())
     const { t }= useTranslation();
+
+    const mapChildNodes = (nodes: ExtendTreeNodeInfo[]): ExtendTreeNodeInfo[] =>
+        nodes.map(c => ({
+            ...c,
+            icon: c.isFile ? <div className={styles.treeIcon}>{TreeIcon(c.id.toString())}</div> : 'folder-close'
+        }));
 
     useEffect(() => {
         const fn = async () => {
@@ -38,10 +46,7 @@ export const WorkSpace = (props: WorkSpaceProps) => {
                     nodeData: {
                         path: currentWorkspace
                     },
-                    childNodes: childNodes.map(c => ({
-                        ...c,
-                        icon: c.isFile ? <div className={styles.treeIcon}>{TreeIcon(c.id.toString())}</div> : 'folder-close'
-                    }))
+                    childNodes: mapChildNodes(childNodes)
                 })
             }
         }
@@ -56,13 +61,43 @@ export const WorkSpace = (props: WorkSpaceProps) => {
     const handleNodeExpand = async (node: ExtendTreeNodeInfo) => {
         if (node.childNodes && node.childNodes.length === 0) {
             let childNodes = await filesystemProvider.current.fetchFileTree((node.nodeData as any).path as string, node);
-            childNodes = childNodes.map(c => ({
-                ...c,
-                icon: c.isFile ? <div className={styles.treeIcon}>{TreeIcon(c.id.toString())}</div> : 'folder-close'
-            }))
-            setFileTree(updateFileTree(fileTree as ExtendTreeNodeInfo, node.nodeData.path, { isExpanded: true, childNodes }))
+            setFileTree(updateFileTree(fileTree as ExtendTreeNodeInfo, node.nodeData.path, { isExpanded: true, childNodes: mapChildNodes(childNodes) }))
         } else {
             setFileTree(updateFileTree(fileTree as ExtendTreeNodeInfo, node.nodeData.path, { isExpanded: true }))
+        }
+    }
+
+    const handleNodeContextMenu = (node: ExtendTreeNodeInfo, _nodePath: number[], e: React.MouseEvent<HTMLElement>) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setContextMenu({ x: e.clientX, y: e.clientY, node });
+    }
+
+    const closeContextMenu = () => setContextMenu(null)
+
+    const refreshTree = async () => {
+        if (!currentWorkspace) return;
+        const childNodes = await filesystemProvider.current.fetchFileTree(currentWorkspace, null);
+        setFileTree(prev => prev ? { ...prev, childNodes: mapChildNodes(childNodes) } : prev);
+    }
+
+    const refreshNode = async (node: ExtendTreeNodeInfo) => {
+        if (node.isFile) {
+            await refreshTree();
+            return;
+        }
+        const childNodes = await filesystemProvider.current.fetchFileTree(node.nodeData.path, node);
+        setFileTree(prev => prev ? updateFileTree(prev, node.nodeData.path, {
+            isExpanded: true,
+            childNodes: mapChildNodes(childNodes)
+        }) : prev);
+    }
+
+    const copyPath = async (path: string) => {
+        try {
+            await navigator.clipboard.writeText(path);
+        } catch (error) {
+            console.error('复制路径失败:', error);
         }
     }
 
@@ -100,6 +135,28 @@ export const WorkSpace = (props: WorkSpaceProps) => {
         return { ...tree, isSelected: false };
     }
 
+    const buildContextMenuItems = (): ContextMenuItem[] => {
+        if (!contextMenu) return [];
+        const { node } = contextMenu;
+        return [
+            ...(node.isFile ? [{
+                label: t('tree.open'),
+                icon: 'document-open' as const,
+                onClick: () => props.onFileOpen(node.nodeData.path)
+            }] : []),
+            {
+                label: t('tree.refresh'),
+                icon: 'refresh' as const,
+                onClick: () => refreshNode(node)
+            },
+            {
+                label: t('tree.copyPath'),
+                icon: 'clipboard' as const,
+                onClick: () => copyPath(node.nodeData.path)
+            }
+        ];
+    }
+
     return (
         <div className={styles.workspace}>
             <div className={styles.title}>
@@ -132,6 +189,7 @@ export const WorkSpace = (props: WorkSpaceProps) => {
                         onNodeExpand={handleNodeExpand}
                         onNodeCollapse={handleNodeCollapse}
                         onNodeClick={handleNodeClick}
+                        onNodeContextMenu={handleNodeContextMenu}
                         className={styles.tree}
                     />
                 </div>
@@ -146,6 +204,14 @@ export const WorkSpace = (props: WorkSpaceProps) => {
                         <Button onClick={onSelectWorkflow} icon="generate" size="large" variant="solid">{t('sfpw')}</Button>
                     </div>
                 </div>
+            )}
+            {contextMenu && (
+                <ContextMenu
+                    x={contextMenu.x}
+                    y={contextMenu.y}
+                    items={buildContextMenuItems()}
+                    onClose={closeContextMenu}
+                />
             )}
         </div>
     )

--- a/desktop/src/i18n/locales/en-us.json
+++ b/desktop/src/i18n/locales/en-us.json
@@ -4,6 +4,16 @@
     "nodyc": "No directory is currently open, you can:",
     "ocapw": "Or, choose from our preset workflows:",
     "wsp": "Workspace",
+    "tree": {
+        "open": "Open",
+        "refresh": "Refresh",
+        "copyPath": "Copy Path"
+    },
+    "tabs": {
+        "close": "Close Tab",
+        "closeOthers": "Close Other Tabs",
+        "closeAll": "Close All Tabs"
+    },
     "dmg": "Download Model Group",
     "preset": "Preset Model Group",
     "local": "Local Models",

--- a/desktop/src/i18n/locales/zh-cn.json
+++ b/desktop/src/i18n/locales/zh-cn.json
@@ -4,6 +4,16 @@
     "nodyc": "当前没有打开的目录, 您可以：",
     "ocapw": "或者，选择我们准备的预制工作流：",
     "wsp": "工作空间",
+    "tree": {
+        "open": "打开",
+        "refresh": "刷新",
+        "copyPath": "复制路径"
+    },
+    "tabs": {
+        "close": "关闭标签页",
+        "closeOthers": "关闭其他标签页",
+        "closeAll": "关闭全部标签页"
+    },
     "dmg": "下载模型组",
     "preset": "预制模型组",
     "local": "本地模型",

--- a/extensions/Image/canvas/App.tsx
+++ b/extensions/Image/canvas/App.tsx
@@ -8,22 +8,33 @@ import { FloatingPanel } from './FloatingPanel';
 import { SidePanel } from './SidePanel';
 import Toolbar from './Toolbar';
 import { produce } from 'immer';
+import { ContextMenu, ContextMenuItem } from 'ssui_components';
 
 const GRID_SIZE = 64;
 const TARGET_SIZE = 512;
 
 interface DrawableObject {
+    id: string;
     type: string;
     x: number;
     y: number;
     obj: React.ReactNode;
 }
+
+interface ContextMenuState {
+    x: number;
+    y: number;
+    items: ContextMenuItem[];
+}
+
 interface AIDrawingCanvasState {
     targetPosition: {
         x: number;
         y: number;
     };
     isDragging: boolean;
+    showGrid: boolean;
+    contextMenu: ContextMenuState | null;
     layers: {
         id: string;
         name: string;
@@ -53,6 +64,8 @@ class AIDrawingCanvas extends React.Component<{path: string}, AIDrawingCanvasSta
         this.state = {
             targetPosition: { x: 0, y: 0 },
             isDragging: false,
+            showGrid: true,
+            contextMenu: null,
             layers: [
                 {
                     id: 'layer1',
@@ -74,6 +87,12 @@ class AIDrawingCanvas extends React.Component<{path: string}, AIDrawingCanvasSta
         this.stageRef = React.createRef();
         this.containerRef = React.createRef();
     }
+
+    private generateObjectId = (): string =>
+        `obj_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+    private generateLayerId = (): string =>
+        `layer_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
 
     componentDidMount() {
         this.updateContainerSize();
@@ -176,6 +195,190 @@ class AIDrawingCanvas extends React.Component<{path: string}, AIDrawingCanvasSta
         }));
     };
 
+    handleLayerSelect = (layerId: string) => {
+        this.setState({ activeLayer: layerId });
+    };
+
+    addLayer = () => {
+        const layer = {
+            id: this.generateLayerId(),
+            name: `图层 ${this.state.layers.length + 1}`,
+            visible: true,
+            locked: false,
+            opacity: 1,
+            objects: [] as DrawableObject[]
+        };
+        this.setState(prevState => ({
+            layers: [...prevState.layers, layer],
+            activeLayer: layer.id
+        }));
+    };
+
+    duplicateLayer = (layerId: string) => {
+        this.setState(prevState => produce(prevState, draft => {
+            const index = draft.layers.findIndex(layer => layer.id === layerId);
+            if (index === -1) return;
+            const source = draft.layers[index];
+            const copy = {
+                ...source,
+                id: this.generateLayerId(),
+                name: `${source.name} 副本`,
+                objects: source.objects.map(obj => ({
+                    ...obj,
+                    id: this.generateObjectId()
+                }))
+            };
+            draft.layers.splice(index + 1, 0, copy);
+        }));
+    };
+
+    deleteLayer = (layerId: string) => {
+        this.setState(prevState => produce(prevState, draft => {
+            if (draft.layers.length <= 1) return;
+            const index = draft.layers.findIndex(layer => layer.id === layerId);
+            if (index === -1) return;
+            draft.layers.splice(index, 1);
+            if (draft.activeLayer === layerId) {
+                const next = draft.layers[Math.min(index, draft.layers.length - 1)];
+                draft.activeLayer = next.id;
+            }
+        }));
+    };
+
+    renameLayer = (layerId: string) => {
+        const layer = this.state.layers.find(layer => layer.id === layerId);
+        if (!layer) return;
+        const name = window.prompt('图层名称', layer.name);
+        if (name && name.trim()) {
+            this.handleLayerChange(layerId, { name: name.trim() });
+        }
+    };
+
+    moveLayer = (layerId: string, direction: 'up' | 'down') => {
+        this.setState(prevState => produce(prevState, draft => {
+            const index = draft.layers.findIndex(layer => layer.id === layerId);
+            const target = direction === 'up' ? index - 1 : index + 1;
+            if (index === -1 || target < 0 || target >= draft.layers.length) return;
+            const [layer] = draft.layers.splice(index, 1);
+            draft.layers.splice(target, 0, layer);
+        }));
+    };
+
+    toggleGrid = () => {
+        this.setState(prevState => ({ showGrid: !prevState.showGrid }));
+    };
+
+    zoomViewport = (factor: number) => {
+        const newViewport = this.state.viewport.zoomBy(factor);
+        this.setState({
+            viewport: newViewport,
+            worldPosition: this.state.worldPosition.setPosition(
+                -newViewport.position.x / newViewport.scale,
+                -newViewport.position.y / newViewport.scale
+            )
+        });
+    };
+
+    resetViewport = () => {
+        const newViewport = this.state.viewport.resetView();
+        this.setState({
+            viewport: newViewport,
+            worldPosition: this.state.worldPosition.setPosition(0, 0)
+        });
+    };
+
+    openContextMenu = (x: number, y: number, items: ContextMenuItem[]) => {
+        this.setState({ contextMenu: { x, y, items } });
+    };
+
+    closeContextMenu = () => {
+        this.setState({ contextMenu: null });
+    };
+
+    // 画布空白处右键菜单
+    handleCanvasContextMenu = (e: any) => {
+        e.evt.preventDefault();
+        if (this.state.viewport.isDraggingViewport()) {
+            return;
+        }
+        const items: ContextMenuItem[] = [
+            { label: '新建图层', icon: 'add', onClick: this.addLayer },
+            { label: this.state.showGrid ? '隐藏网格' : '显示网格', icon: 'grid', onClick: this.toggleGrid },
+            { dividerBefore: true },
+            { label: '放大', icon: 'zoom-in', onClick: () => this.zoomViewport(1.2) },
+            { label: '缩小', icon: 'zoom-out', onClick: () => this.zoomViewport(1 / 1.2) },
+            { label: '重置视图', icon: 'zoom-to-fit', onClick: this.resetViewport }
+        ];
+        this.openContextMenu(e.evt.clientX, e.evt.clientY, items);
+    };
+
+    // 画布对象右键菜单
+    openObjectMenu = (e: any, layerId: string, objectId: string) => {
+        e.evt.preventDefault();
+        e.cancelBubble = true;
+        const items: ContextMenuItem[] = [
+            { label: '复制对象', icon: 'duplicate', onClick: () => this.duplicateObject(layerId, objectId) },
+            { label: '置于顶层', icon: 'bring-forward', onClick: () => this.moveObject(layerId, objectId, 'front') },
+            { label: '置于底层', icon: 'send-backward', onClick: () => this.moveObject(layerId, objectId, 'back') },
+            { dividerBefore: true, label: '删除对象', icon: 'trash', intent: 'danger', onClick: () => this.deleteObject(layerId, objectId) }
+        ];
+        this.openContextMenu(e.evt.clientX, e.evt.clientY, items);
+    };
+
+    renderObject = (layerId: string, object: DrawableObject) => {
+        const element = object.obj as React.ReactElement;
+        return React.cloneElement(element, {
+            onContextMenu: (e: any) => this.openObjectMenu(e, layerId, object.id)
+        });
+    };
+
+    duplicateObject = (layerId: string, objectId: string) => {
+        this.setState(prevState => produce(prevState, draft => {
+            const layer = draft.layers.find(layer => layer.id === layerId);
+            if (!layer) return;
+            const index = layer.objects.findIndex(obj => obj.id === objectId);
+            if (index === -1) return;
+            const source = layer.objects[index];
+            const copy = {
+                id: this.generateObjectId(),
+                type: source.type,
+                x: source.x + GRID_SIZE,
+                y: source.y + GRID_SIZE,
+                obj: React.cloneElement(source.obj as React.ReactElement, {
+                    x: source.x + GRID_SIZE,
+                    y: source.y + GRID_SIZE
+                })
+            };
+            layer.objects.splice(index + 1, 0, copy);
+        }));
+    };
+
+    deleteObject = (layerId: string, objectId: string) => {
+        this.setState(prevState => produce(prevState, draft => {
+            const layer = draft.layers.find(layer => layer.id === layerId);
+            if (!layer) return;
+            const index = layer.objects.findIndex(obj => obj.id === objectId);
+            if (index !== -1) {
+                layer.objects.splice(index, 1);
+            }
+        }));
+    };
+
+    moveObject = (layerId: string, objectId: string, position: 'front' | 'back') => {
+        this.setState(prevState => produce(prevState, draft => {
+            const layer = draft.layers.find(layer => layer.id === layerId);
+            if (!layer) return;
+            const index = layer.objects.findIndex(obj => obj.id === objectId);
+            if (index === -1) return;
+            const [obj] = layer.objects.splice(index, 1);
+            if (position === 'front') {
+                layer.objects.push(obj);
+            } else {
+                layer.objects.unshift(obj);
+            }
+        }));
+    };
+
     handleToolSelect = (tool: string) => {
         console.log('Selected tool:', tool);
         // 这里可以添加工具选择的处理逻辑
@@ -235,16 +438,19 @@ class AIDrawingCanvas extends React.Component<{path: string}, AIDrawingCanvasSta
             console.log('开始创建 ImageBitmap');
             const image = await createImageBitmap(img);
             console.log('ImageBitmap 创建成功');
+
+            const position = this.state.targetPosition;
             
             this.setState(state => produce(state, draft => {
                 const layer = draft.layers.find(layer => layer.id === draft.activeLayer);
                 if (layer) {
-                    console.log('添加图片', this.state.targetPosition.x, this.state.targetPosition.y);
+                    console.log('添加图片', position.x, position.y);
                     layer.objects.push({
+                        id: this.generateObjectId(),
                         type: 'image',
-                        x: this.state.targetPosition.x,
-                        y: this.state.targetPosition.y,
-                        obj: <Image image={image} x={this.state.targetPosition.x} y={this.state.targetPosition.y} />
+                        x: position.x,
+                        y: position.y,
+                        obj: <Image image={image} x={position.x} y={position.y} />
                     });
                 }
             }));
@@ -255,7 +461,7 @@ class AIDrawingCanvas extends React.Component<{path: string}, AIDrawingCanvasSta
     };
 
     render() {
-        const { targetPosition, isDragging, layers, brushPosition, brushSize } = this.state;
+        const { targetPosition, isDragging, layers, brushPosition, brushSize, contextMenu } = this.state;
         const viewport = this.state.viewport;
         const worldPos = this.state.worldPosition;
         return (
@@ -286,7 +492,7 @@ class AIDrawingCanvas extends React.Component<{path: string}, AIDrawingCanvasSta
                     onMouseMove={this.handleViewportDragMove}
                     onMouseUp={this.handleViewportDragEnd}
                     onWheel={this.handleWheel}
-                    onContextMenu={(e) => e.evt.preventDefault()}
+                    onContextMenu={this.handleCanvasContextMenu}
                     scaleX={viewport.scale}
                     scaleY={viewport.scale}
                     x={worldPos.x}
@@ -296,7 +502,11 @@ class AIDrawingCanvas extends React.Component<{path: string}, AIDrawingCanvasSta
                         <Layer key={layer.id} opacity={layer.opacity}>
                             {layer.visible && (
                                 layer.objects.map((object) => {
-                                    return object.obj;
+                                    return (
+                                        <React.Fragment key={object.id}>
+                                            {this.renderObject(layer.id, object)}
+                                        </React.Fragment>
+                                    );
                                 })
                             )}
                         </Layer>
@@ -305,7 +515,7 @@ class AIDrawingCanvas extends React.Component<{path: string}, AIDrawingCanvasSta
 
                     <Layer>
                         {/* 渲染网格 */}
-                        <Grid viewport={viewport} />
+                        {this.state.showGrid && <Grid viewport={viewport} />}
                         
                         {this.state.selectedTool === 'move' && (
                             <Rect
@@ -346,8 +556,25 @@ class AIDrawingCanvas extends React.Component<{path: string}, AIDrawingCanvasSta
                 {/* 添加侧边面板 */}
                 <SidePanel 
                     layers={layers}
+                    activeLayer={this.state.activeLayer}
                     onLayerChange={this.handleLayerChange}
+                    onLayerSelect={this.handleLayerSelect}
+                    onAddLayer={this.addLayer}
+                    onDuplicateLayer={this.duplicateLayer}
+                    onDeleteLayer={this.deleteLayer}
+                    onRenameLayer={this.renameLayer}
+                    onMoveLayer={this.moveLayer}
                 />
+
+                {/* 右键菜单 */}
+                {contextMenu && (
+                    <ContextMenu
+                        x={contextMenu.x}
+                        y={contextMenu.y}
+                        items={contextMenu.items}
+                        onClose={this.closeContextMenu}
+                    />
+                )}
             </div>
         );
     }

--- a/extensions/Image/canvas/App.tsx
+++ b/extensions/Image/canvas/App.tsx
@@ -146,7 +146,7 @@ class AIDrawingCanvas extends React.Component<{path: string}, AIDrawingCanvasSta
 
     // 视口拖动相关处理
     handleViewportDragStart = (e: any) => {
-        if (e.evt.button === 1 || e.evt.button === 2) { // 中键或右键
+        if (e.evt.button === 1) { // 中键拖动视口（右键已用于上下文菜单）
             e.evt.preventDefault();
             const stage = this.stageRef.current;
             const pointer = stage.getPointerPosition();

--- a/extensions/Image/canvas/SidePanel.css
+++ b/extensions/Image/canvas/SidePanel.css
@@ -41,6 +41,12 @@
 
 .layer-card {
     margin-bottom: 10px;
+    cursor: pointer;
+}
+
+.layer-card-active {
+    border: 2px solid #2d72d2;
+    box-shadow: 0 0 0 1px rgba(45, 114, 210, 0.3);
 }
 
 .layer-header {

--- a/extensions/Image/canvas/SidePanel.tsx
+++ b/extensions/Image/canvas/SidePanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Card, Elevation, Button, Icon } from "@blueprintjs/core";
+import { ContextMenu, ContextMenuItem } from 'ssui_components';
 import './SidePanel.css';
 
 interface Layer {
@@ -12,13 +13,70 @@ interface Layer {
 
 interface SidePanelProps {
     layers: Layer[];
+    activeLayer: string;
     onLayerChange: (layerId: string, changes: Partial<Layer>) => void;
+    onLayerSelect?: (layerId: string) => void;
+    onAddLayer?: () => void;
+    onDuplicateLayer?: (layerId: string) => void;
+    onDeleteLayer?: (layerId: string) => void;
+    onRenameLayer?: (layerId: string) => void;
+    onMoveLayer?: (layerId: string, direction: 'up' | 'down') => void;
 }
 
-export class SidePanel extends React.Component<SidePanelProps> {
+interface SidePanelState {
+    contextMenu: {
+        x: number;
+        y: number;
+        layerId: string;
+    } | null;
+}
+
+export class SidePanel extends React.Component<SidePanelProps, SidePanelState> {
+    constructor(props: SidePanelProps) {
+        super(props);
+        this.state = {
+            contextMenu: null
+        };
+    }
+
+    openLayerContextMenu = (e: React.MouseEvent, layerId: string) => {
+        e.preventDefault();
+        e.stopPropagation();
+        this.props.onLayerSelect?.(layerId);
+        this.setState({
+            contextMenu: {
+                x: e.clientX,
+                y: e.clientY,
+                layerId
+            }
+        });
+    };
+
+    openEmptyContextMenu = (e: React.MouseEvent) => {
+        e.preventDefault();
+        this.setState({
+            contextMenu: {
+                x: e.clientX,
+                y: e.clientY,
+                layerId: ''
+            }
+        });
+    };
+
+    closeContextMenu = () => {
+        this.setState({ contextMenu: null });
+    };
+
     renderLayer = (layer: Layer) => {
+        const isActive = layer.id === this.props.activeLayer;
         return (
-            <Card key={layer.id} elevation={Elevation.ONE} className="layer-card">
+            <Card
+                key={layer.id}
+                elevation={Elevation.ONE}
+                className={`layer-card ${isActive ? 'layer-card-active' : ''}`}
+                onClick={() => this.props.onLayerSelect?.(layer.id)}
+                onContextMenu={(e) => this.openLayerContextMenu(e, layer.id)}
+            >
                 <div className="layer-header">
                     <div className="layer-name">{layer.name}</div>
                     <div className="layer-controls">
@@ -76,16 +134,46 @@ export class SidePanel extends React.Component<SidePanelProps> {
     }
 
     render() {
+        const { contextMenu } = this.state;
+        const layer = contextMenu
+            ? this.props.layers.find(l => l.id === contextMenu.layerId)
+            : undefined;
+        const items: ContextMenuItem[] = contextMenu
+            ? layer
+                ? [
+                    { label: '重命名图层', icon: 'edit', onClick: () => this.props.onRenameLayer?.(layer.id) },
+                    { label: '复制图层', icon: 'duplicate', onClick: () => this.props.onDuplicateLayer?.(layer.id) },
+                    { dividerBefore: true },
+                    { label: '上移', icon: 'arrow-up', disabled: this.props.layers[0]?.id === layer.id, onClick: () => this.props.onMoveLayer?.(layer.id, 'up') },
+                    { label: '下移', icon: 'arrow-down', disabled: this.props.layers[this.props.layers.length - 1]?.id === layer.id, onClick: () => this.props.onMoveLayer?.(layer.id, 'down') },
+                    { dividerBefore: true },
+                    { label: layer.visible ? '隐藏图层' : '显示图层', icon: layer.visible ? 'eye-off' : 'eye-open', onClick: () => this.props.onLayerChange(layer.id, { visible: !layer.visible }) },
+                    { label: layer.locked ? '解锁图层' : '锁定图层', icon: layer.locked ? 'unlock' : 'lock', onClick: () => this.props.onLayerChange(layer.id, { locked: !layer.locked }) },
+                    { dividerBefore: true, label: '删除图层', icon: 'trash', intent: 'danger', disabled: this.props.layers.length <= 1, onClick: () => this.props.onDeleteLayer?.(layer.id) }
+                ]
+                : [
+                    { label: '新建图层', icon: 'add', onClick: () => this.props.onAddLayer?.() }
+                ]
+            : [];
+
         return (
             <div className="side-panel">
                 {this.renderConfigPanel()}
                 <div className="panel-header">
                     <h3>图层</h3>
-                    <Button minimal icon="plus" />
+                    <Button minimal icon="plus" onClick={() => this.props.onAddLayer?.()} />
                 </div>
-                <div className="layers-list">
+                <div className="layers-list" onContextMenu={this.openEmptyContextMenu}>
                     {this.props.layers.map(this.renderLayer)}
                 </div>
+                {contextMenu && (
+                    <ContextMenu
+                        x={contextMenu.x}
+                        y={contextMenu.y}
+                        items={items}
+                        onClose={this.closeContextMenu}
+                    />
+                )}
             </div>
         );
     }

--- a/extensions/Image/canvas/Viewport.ts
+++ b/extensions/Image/canvas/Viewport.ts
@@ -72,4 +72,43 @@ export class Viewport {
             draft.position = { x: newX, y: newY };
         });
     }
+
+    /**
+     * 以指定屏幕坐标（默认视口中心）为锚点按倍数缩放。
+     */
+    zoomBy(factor: number, center?: { x: number; y: number }) {
+        const oldScale = this.scale;
+        const newScale = Math.min(4, Math.max(0.1, oldScale * factor));
+        if (newScale === oldScale) {
+            return this;
+        }
+
+        const anchor = center ?? {
+            x: this.size.width / 2,
+            y: this.size.height / 2,
+        };
+        const actualFactor = newScale / oldScale;
+        const zoomPoint = {
+            x: anchor.x - this.position.x,
+            y: anchor.y - this.position.y,
+        };
+
+        return produce(this, draft => {
+            draft.scale = newScale;
+            draft.position = {
+                x: anchor.x - zoomPoint.x * actualFactor,
+                y: anchor.y - zoomPoint.y * actualFactor,
+            };
+        });
+    }
+
+    /**
+     * 重置视图：缩放恢复为 1，位置归零。
+     */
+    resetView() {
+        return produce(this, draft => {
+            draft.scale = 1;
+            draft.position = { x: 0, y: 0 };
+        });
+    }
 } 

--- a/frontend/functional_ui/src/ui/preview/ImagePreview.tsx
+++ b/frontend/functional_ui/src/ui/preview/ImagePreview.tsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { Card, Elevation } from "@blueprintjs/core";
+import { ContextMenu, ContextMenuItem } from 'ssui_components';
 import { registerUIProvider, UIProvider } from '../UIProvider';
 import './ImagePreview.css';
 
@@ -11,6 +12,7 @@ interface ImagePreviewState {
     imagePath: string;
     loading: boolean;
     error: Error | null;
+    contextMenu: { x: number; y: number } | null;
 }
 
 export class ImagePreview extends Component<ImagePreviewProps, ImagePreviewState> {
@@ -19,7 +21,8 @@ export class ImagePreview extends Component<ImagePreviewProps, ImagePreviewState
         this.state = {
             imagePath: props.path,
             loading: true,
-            error: null
+            error: null,
+            contextMenu: null
         };
     }
 
@@ -54,8 +57,36 @@ export class ImagePreview extends Component<ImagePreviewProps, ImagePreviewState
         img.src = '/file?path=' + this.state.imagePath;
     }
 
+    handleContextMenu = (e: React.MouseEvent) => {
+        e.preventDefault();
+        this.setState({
+            contextMenu: { x: e.clientX, y: e.clientY }
+        });
+    }
+
+    closeContextMenu = () => {
+        this.setState({ contextMenu: null });
+    }
+
+    copyImageUrl = async () => {
+        const url = '/file?path=' + this.state.imagePath;
+        try {
+            await navigator.clipboard.writeText(url);
+        } catch (error) {
+            console.error('复制图片地址失败:', error);
+        }
+    }
+
+    openImageInNewWindow = () => {
+        window.open('/file?path=' + this.state.imagePath, '_blank', 'noopener');
+    }
+
     render() {
-        const { imagePath, loading, error } = this.state;
+        const { imagePath, loading, error, contextMenu } = this.state;
+        const contextItems: ContextMenuItem[] = [
+            { label: '复制图片地址', icon: 'clipboard', onClick: this.copyImageUrl },
+            { label: '在新窗口打开', icon: 'document-open', onClick: this.openImageInNewWindow }
+        ];
 
         return (
             <div className="image-preview">
@@ -69,9 +100,18 @@ export class ImagePreview extends Component<ImagePreviewProps, ImagePreviewState
                             src={'/file?path=' + imagePath} 
                             alt="Preview" 
                             className="preview-image"
+                            onContextMenu={this.handleContextMenu}
                         />
                     )}
                 </div>
+                {contextMenu && (
+                    <ContextMenu
+                        x={contextMenu.x}
+                        y={contextMenu.y}
+                        items={contextItems}
+                        onClose={this.closeContextMenu}
+                    />
+                )}
             </div>
         );
     }

--- a/frontend/ssui_components/src/ContextMenu.tsx
+++ b/frontend/ssui_components/src/ContextMenu.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { Menu, MenuDivider, MenuItem } from "@blueprintjs/core";
+
+export interface ContextMenuItem {
+    /** 菜单项文本；缺省时渲染为分隔线（可与 dividerBefore 组合使用） */
+    label?: string;
+    icon?: React.ComponentProps<typeof MenuItem>["icon"];
+    disabled?: boolean;
+    intent?: React.ComponentProps<typeof MenuItem>["intent"];
+    dividerBefore?: boolean;
+    onClick?: () => void;
+}
+
+export interface ContextMenuProps {
+    x: number;
+    y: number;
+    items: ContextMenuItem[];
+    onClose: () => void;
+    className?: string;
+}
+
+/**
+ * 通用浮动右键菜单：在指定屏幕坐标渲染一个 Blueprint 菜单，
+ * 点击菜单外、按 Escape、窗口滚动或失焦时自动关闭。
+ */
+export const ContextMenu: React.FC<ContextMenuProps> = ({
+    x,
+    y,
+    items,
+    onClose,
+    className,
+}) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const handleMouseDown = (e: MouseEvent) => {
+            if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+                onClose();
+            }
+        };
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                onClose();
+            }
+        };
+        const handleClose = () => onClose();
+
+        window.addEventListener("mousedown", handleMouseDown);
+        window.addEventListener("keydown", handleKeyDown);
+        window.addEventListener("resize", handleClose);
+        window.addEventListener("blur", handleClose);
+        window.addEventListener("scroll", handleClose, true);
+
+        return () => {
+            window.removeEventListener("mousedown", handleMouseDown);
+            window.removeEventListener("keydown", handleKeyDown);
+            window.removeEventListener("resize", handleClose);
+            window.removeEventListener("blur", handleClose);
+            window.removeEventListener("scroll", handleClose, true);
+        };
+    }, [onClose]);
+
+    if (items.length === 0) {
+        return null;
+    }
+
+    // 粗略估算菜单高度，用于防止菜单超出视口底部
+    const estimatedHeight = items.reduce((sum, item) => sum + (item.dividerBefore ? 9 : 30), 8);
+    const left = Math.min(Math.max(x, 4), window.innerWidth - 220);
+    const top = Math.min(Math.max(y, 4), window.innerHeight - estimatedHeight);
+
+    const menu = (
+        <div
+            ref={containerRef}
+            className={className}
+            style={{
+                position: "fixed",
+                left,
+                top,
+                zIndex: 3000,
+                background: "#ffffff",
+                borderRadius: 6,
+                boxShadow: "0 2px 12px rgba(0, 0, 0, 0.25)",
+            }}
+            onContextMenu={(e) => e.preventDefault()}
+        >
+            <Menu>
+                {items.map((item, index) => {
+                    if (!item.label) {
+                        return <MenuDivider key={index} />;
+                    }
+
+                    const menuItem = (
+                        <MenuItem
+                            key={index}
+                            text={item.label}
+                            icon={item.icon}
+                            disabled={item.disabled}
+                            intent={item.intent}
+                            onClick={() => {
+                                onClose();
+                                item.onClick?.();
+                            }}
+                        />
+                    );
+
+                    return item.dividerBefore ? (
+                        <React.Fragment key={index}>
+                            <MenuDivider />
+                            {menuItem}
+                        </React.Fragment>
+                    ) : (
+                        menuItem
+                    );
+                })}
+            </Menu>
+        </div>
+    );
+
+    // 通过 Portal 渲染到 body，避免父级 overflow / filter / backdrop-filter 造成的裁剪与定位偏差
+    return createPortal(menu, document.body);
+};
+
+export default ContextMenu;

--- a/frontend/ssui_components/src/index.ts
+++ b/frontend/ssui_components/src/index.ts
@@ -4,4 +4,5 @@ export * from './controllers/InternalControllers';
 export * from './components/InternalComponents';
 export * from './components/ComponentRef';
 export * from './controllers/ControllerRef';
+export * from './ContextMenu';
 export * from './shared/Workflow';


### PR DESCRIPTION
## 概述

在 UI 中多处合适位置添加右键菜单，核心是 Image Canvas 画布。

### 变更内容

- **共享组件**：在 \ssui_components\ 中新增通用浮动 \ContextMenu\ 组件（Portal 渲染、点击外部/Escape 自动关闭）。
- **Canvas（Image 扩展）**：
  - 空白处右键：新建图层、显示/隐藏网格、放大、缩小、重置视图
  - 对象（图片）右键：复制对象、置于顶层/底层、删除对象
  - Viewport 新增 \zoomBy\ / \esetView\
- **图层面板**：右键重命名、复制、上移/下移、显示/隐藏、锁定/解锁、删除图层；面板空白处右键新建图层。
- **桌面标签页**：右键关闭当前、关闭其他、关闭全部（含中英文 i18n）。
- **工作空间文件树**：右键打开（文件）、刷新、复制路径（含 i18n）。
- **图片预览**：右键复制图片地址、在新窗口打开。

### 验证

\ssui_components\、\xtensions/Image\、\unctional_ui\、\desktop\ 四个包的 \	sc\ 与 \ite build\ 均通过。