### PR TITLE
feat(tree): 文件树支持新建文件/绘图板与删除

### DIFF
--- a/desktop/src/components/WorkSpace/index.tsx
+++ b/desktop/src/components/WorkSpace/index.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useState,useRef} from 'react';
-import {Button, Tree, Icon, Popover, Menu, MenuItem} from "@blueprintjs/core";
+import {Button, Tree, Icon, Popover, Menu, MenuItem, Dialog, FormGroup, InputGroup, Intent} from "@blueprintjs/core";
 import { ContextMenu, ContextMenuItem } from 'ssui_components';
 import { TauriFilesystemProvider, IFilesystemProvider, ExtendTreeNodeInfo } from '../../providers/FilesystemProvider';
 import styles from './style.module.css'
@@ -22,6 +22,11 @@ export const WorkSpace = (props: WorkSpaceProps) => {
     const { currentWorkspace, onOpenWorkspace, onSelectWorkflow } = props
     const [ fileTree, setFileTree ] = useState<ExtendTreeNodeInfo>()
     const [ contextMenu, setContextMenu ] = useState<{ x: number; y: number; node: ExtendTreeNodeInfo } | null>(null)
+    const [ createDialog, setCreateDialog ] = useState<{ kind: 'file' | 'canvas'; parentNode: ExtendTreeNodeInfo | null } | null>(null)
+    const [ deleteDialog, setDeleteDialog ] = useState<{ node: ExtendTreeNodeInfo } | null>(null)
+    const [ inputName, setInputName ] = useState('')
+    const [ inputError, setInputError ] = useState<string | null>(null)
+    const [ busy, setBusy ] = useState(false)
     const filesystemProvider = useRef<IFilesystemProvider>(props.filesystemProvider || new TauriFilesystemProvider())
     const { t }= useTranslation();
 
@@ -101,6 +106,67 @@ export const WorkSpace = (props: WorkSpaceProps) => {
         }
     }
 
+    const openCreateDialog = (parentNode: ExtendTreeNodeInfo | null, kind: 'file' | 'canvas') => {
+        setInputName('');
+        setInputError(null);
+        setCreateDialog({ kind, parentNode });
+    };
+
+    const closeCreateDialog = () => {
+        if (busy) return;
+        setCreateDialog(null);
+    };
+
+    const confirmCreate = async () => {
+        if (!createDialog || busy) return;
+        const name = inputName.trim();
+        if (!name) {
+            setInputError(t('tree.nameRequired'));
+            return;
+        }
+        setBusy(true);
+        try {
+            const { kind, parentNode } = createDialog;
+            const dir = parentNode ? parentNode.nodeData.path : currentWorkspace;
+            if (!dir) {
+                setInputError(t('tree.createFailed'));
+                return;
+            }
+            const createdPath = kind === 'canvas'
+                ? await filesystemProvider.current.createCanvas(dir, name)
+                : await filesystemProvider.current.createFile(dir, name);
+            if (!createdPath) {
+                setInputError(t('tree.createFailed'));
+                return;
+            }
+            setCreateDialog(null);
+            if (kind === 'canvas') {
+                props.onFileOpen(createdPath);
+            }
+            if (parentNode) {
+                await refreshNode(parentNode);
+            } else {
+                await refreshTree();
+            }
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const confirmDelete = async () => {
+        if (!deleteDialog || busy) return;
+        setBusy(true);
+        try {
+            const ok = await filesystemProvider.current.deletePath(deleteDialog.node.nodeData.path);
+            setDeleteDialog(null);
+            if (ok) {
+                await refreshTree();
+            }
+        } finally {
+            setBusy(false);
+        }
+    };
+
     const handleNodeClick = (node: ExtendTreeNodeInfo) => {
         // 先把所有节点的选择态清空
         setFileTree((prevState) => {
@@ -138,12 +204,27 @@ export const WorkSpace = (props: WorkSpaceProps) => {
     const buildContextMenuItems = (): ContextMenuItem[] => {
         if (!contextMenu) return [];
         const { node } = contextMenu;
-        return [
-            ...(node.isFile ? [{
+        const items: ContextMenuItem[] = [];
+        if (node.isFile) {
+            items.push({
                 label: t('tree.open'),
                 icon: 'document-open' as const,
                 onClick: () => props.onFileOpen(node.nodeData.path)
-            }] : []),
+            });
+        } else {
+            items.push({
+                label: t('tree.newFile'),
+                icon: 'document' as const,
+                onClick: () => openCreateDialog(node, 'file')
+            });
+            items.push({
+                label: t('tree.newCanvas'),
+                icon: 'media' as const,
+                onClick: () => openCreateDialog(node, 'canvas')
+            });
+            items.push({ dividerBefore: true });
+        }
+        items.push(
             {
                 label: t('tree.refresh'),
                 icon: 'refresh' as const,
@@ -153,8 +234,15 @@ export const WorkSpace = (props: WorkSpaceProps) => {
                 label: t('tree.copyPath'),
                 icon: 'clipboard' as const,
                 onClick: () => copyPath(node.nodeData.path)
+            },
+            {
+                label: t('tree.delete'),
+                icon: 'trash' as const,
+                intent: Intent.DANGER,
+                onClick: () => setDeleteDialog({ node })
             }
-        ];
+        );
+        return items;
     }
 
     return (
@@ -167,6 +255,8 @@ export const WorkSpace = (props: WorkSpaceProps) => {
                             <Menu key="menu">
                                 <MenuItem icon="folder-open" text={t('onw')} onClick={onOpenWorkspace} />
                                 <MenuItem icon="generate" text={t('sfpw')} onClick={onSelectWorkflow} />
+                                <MenuItem icon="document" text={t('tree.newFile')} onClick={() => openCreateDialog(null, 'file')} />
+                                <MenuItem icon="media" text={t('tree.newCanvas')} onClick={() => openCreateDialog(null, 'canvas')} />
                             </Menu>
                         }
                         position="bottom-right"
@@ -213,6 +303,48 @@ export const WorkSpace = (props: WorkSpaceProps) => {
                     onClose={closeContextMenu}
                 />
             )}
+            <Dialog
+                isOpen={createDialog !== null}
+                onClose={closeCreateDialog}
+                title={createDialog?.kind === 'canvas' ? t('tree.createCanvasTitle') : t('tree.createFileTitle')}
+            >
+                <div style={{ padding: '20px' }}>
+                    <FormGroup label={t('tree.name')} labelFor="tree-input-name">
+                        <InputGroup
+                            id="tree-input-name"
+                            autoFocus
+                            placeholder={createDialog?.kind === 'canvas' ? t('tree.canvasNamePlaceholder') : t('tree.fileNamePlaceholder')}
+                            value={inputName}
+                            onChange={(e) => {
+                                setInputName(e.target.value);
+                                setInputError(null);
+                            }}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter') confirmCreate();
+                            }}
+                            intent={inputError ? Intent.DANGER : Intent.NONE}
+                        />
+                        {inputError && <div style={{ color: 'red', marginTop: '5px' }}>{inputError}</div>}
+                    </FormGroup>
+                </div>
+                <div className="bp5-dialog-footer">
+                    <Button onClick={closeCreateDialog} disabled={busy}>{t('tree.cancel')}</Button>
+                    <Button intent={Intent.PRIMARY} onClick={confirmCreate} loading={busy}>{t('tree.create')}</Button>
+                </div>
+            </Dialog>
+            <Dialog
+                isOpen={deleteDialog !== null}
+                onClose={() => { if (!busy) setDeleteDialog(null); }}
+                title={t('tree.deleteConfirmTitle')}
+            >
+                <div style={{ padding: '20px' }}>
+                    <p>{t('tree.deleteConfirmMessage', { name: deleteDialog?.node.label || '' })}</p>
+                </div>
+                <div className="bp5-dialog-footer">
+                    <Button onClick={() => setDeleteDialog(null)} disabled={busy}>{t('tree.cancel')}</Button>
+                    <Button intent={Intent.DANGER} onClick={confirmDelete} loading={busy}>{t('tree.delete')}</Button>
+                </div>
+            </Dialog>
         </div>
     )
 }

--- a/desktop/src/i18n/locales/en-us.json
+++ b/desktop/src/i18n/locales/en-us.json
@@ -7,7 +7,22 @@
     "tree": {
         "open": "Open",
         "refresh": "Refresh",
-        "copyPath": "Copy Path"
+        "copyPath": "Copy Path",
+        "newFile": "New File",
+        "newCanvas": "New Canvas",
+        "delete": "Delete",
+        "createFileTitle": "New File",
+        "createCanvasTitle": "New Canvas",
+        "name": "Name",
+        "namePlaceholder": "Enter file name",
+        "fileNamePlaceholder": "e.g. script.py",
+        "canvasNamePlaceholder": "e.g. My Canvas",
+        "nameRequired": "Name cannot be empty",
+        "create": "Create",
+        "cancel": "Cancel",
+        "createFailed": "Failed to create. Check the name is valid and does not already exist",
+        "deleteConfirmTitle": "Confirm Delete",
+        "deleteConfirmMessage": "Are you sure you want to delete \"{{name}}\"? This action cannot be undone."
     },
     "tabs": {
         "close": "Close Tab",

--- a/desktop/src/i18n/locales/zh-cn.json
+++ b/desktop/src/i18n/locales/zh-cn.json
@@ -7,7 +7,22 @@
     "tree": {
         "open": "打开",
         "refresh": "刷新",
-        "copyPath": "复制路径"
+        "copyPath": "复制路径",
+        "newFile": "新建文件",
+        "newCanvas": "新建绘图板",
+        "delete": "删除",
+        "createFileTitle": "新建文件",
+        "createCanvasTitle": "新建绘图板",
+        "name": "名称",
+        "namePlaceholder": "请输入文件名称",
+        "fileNamePlaceholder": "例如：script.py",
+        "canvasNamePlaceholder": "例如：我的画板",
+        "nameRequired": "名称不能为空",
+        "create": "创建",
+        "cancel": "取消",
+        "createFailed": "创建失败，请检查名称是否合法或已存在",
+        "deleteConfirmTitle": "删除确认",
+        "deleteConfirmMessage": "确定要删除「{{name}}」吗？此操作不可恢复。"
     },
     "tabs": {
         "close": "关闭标签页",

--- a/desktop/src/providers/FilesystemProvider.ts
+++ b/desktop/src/providers/FilesystemProvider.ts
@@ -1,10 +1,16 @@
 import { TreeNodeInfo } from "@blueprintjs/core";
-import { readDir } from '@tauri-apps/plugin-fs';
+import { readDir, writeTextFile, remove } from '@tauri-apps/plugin-fs';
 import { join } from '@tauri-apps/api/path';
 
 export interface IFilesystemProvider {
     fetchFileTree(directory: string, parent: ExtendTreeNodeInfo | null): Promise<ExtendTreeNodeInfo[]>;
     getPathToRoot(node: TreeNodeInfo): string[];
+    /** 在指定目录下新建空文件，成功返回完整路径，失败返回 null */
+    createFile(parentPath: string, name: string): Promise<string | null>;
+    /** 在指定目录下新建绘图板文件（自动补 .canvas 后缀），成功返回完整路径，失败返回 null */
+    createCanvas(parentPath: string, name: string): Promise<string | null>;
+    /** 删除文件或目录（目录递归删除），成功返回 true */
+    deletePath(path: string): Promise<boolean>;
 }
 
 export interface ExtendTreeNodeInfo extends TreeNodeInfo {
@@ -69,6 +75,35 @@ export class TauriFilesystemProvider implements IFilesystemProvider {
             currentNode = (currentNode.nodeData as any)?.parent as TreeNodeInfo | null;
         }
         return path;
+    }
+
+    async createFile(parentPath: string, name: string): Promise<string | null> {
+        try {
+            if (!name.trim()) {
+                throw new Error('File name is empty');
+            }
+            const fullPath = await join(parentPath, name);
+            await writeTextFile(fullPath, '');
+            return fullPath;
+        } catch (error) {
+            console.error('Error creating file:', error);
+            return null;
+        }
+    }
+
+    async createCanvas(parentPath: string, name: string): Promise<string | null> {
+        const canvasName = name.trim().endsWith('.canvas') ? name.trim() : `${name.trim()}.canvas`;
+        return this.createFile(parentPath, canvasName);
+    }
+
+    async deletePath(path: string): Promise<boolean> {
+        try {
+            await remove(path, { recursive: true });
+            return true;
+        } catch (error) {
+            console.error('Error deleting path:', error);
+            return false;
+        }
     }
 }
 

--- a/desktop/src/stories/MockFilesystemProvider.ts
+++ b/desktop/src/stories/MockFilesystemProvider.ts
@@ -3,6 +3,7 @@ import { IFilesystemProvider, ExtendTreeNodeInfo } from "../providers/Filesystem
 
 export class MockFilesystemProvider implements IFilesystemProvider {
     private mockFileSystem: Map<string, ExtendTreeNodeInfo[]> = new Map();
+    private idCounter: number = 0;
 
     constructor() {
         // 初始化模拟文件系统结构
@@ -145,6 +146,47 @@ export class MockFilesystemProvider implements IFilesystemProvider {
             currentNode = (currentNode.nodeData as any).parent as TreeNodeInfo | null;
         }
         return path;
+    }
+
+    private async addMockNode(parentPath: string, name: string): Promise<string | null> {
+        const fullPath = `${parentPath}/${name}`;
+        const files = this.mockFileSystem.get(parentPath);
+        if (!files) {
+            return null;
+        }
+        if (files.some(f => f.label === name)) {
+            return null;
+        }
+        this.idCounter += 1;
+        const nodeData = { path: fullPath, parent: null };
+        const node: ExtendTreeNodeInfo = {
+            id: `mock-${this.idCounter}`,
+            label: name,
+            isFile: true,
+            nodeData
+        };
+        files.push(node);
+        return fullPath;
+    }
+
+    public async createFile(parentPath: string, name: string): Promise<string | null> {
+        return this.addMockNode(parentPath, name);
+    }
+
+    public async createCanvas(parentPath: string, name: string): Promise<string | null> {
+        const canvasName = name.trim().endsWith('.canvas') ? name.trim() : `${name.trim()}.canvas`;
+        return this.addMockNode(parentPath, canvasName);
+    }
+
+    public async deletePath(path: string): Promise<boolean> {
+        for (const files of this.mockFileSystem.values()) {
+            const index = files.findIndex(f => f.nodeData.path === path);
+            if (index !== -1) {
+                files.splice(index, 1);
+                return true;
+            }
+        }
+        return false;
     }
 }
 

--- a/desktop/src/stories/mocks/tauriFs.ts
+++ b/desktop/src/stories/mocks/tauriFs.ts
@@ -22,3 +22,7 @@ export async function exists(_path: string): Promise<boolean> {
 export async function writeTextFile(_path: string, _contents: string): Promise<void> {
   // Storybook mock: no-op
 }
+
+export async function remove(_path: string, _options?: { recursive?: boolean }): Promise<void> {
+  // Storybook mock: no-op
+}


### PR DESCRIPTION
对应 v0.2 Roadmap issue #17「文件树」：新增文件、新增绘图板（.canvas）、删除文件/目录，含 i18n 与 Storybook mock 更新。桌面端 build 已验证通过。