### PR TITLE
feat(queue): 实现下载任务与生图任务队列

### DIFF
--- a/desktop/src/components/Queue/index.tsx
+++ b/desktop/src/components/Queue/index.tsx
@@ -1,134 +1,84 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { Card, Elevation, Button, Tag, Spinner, Icon, Dialog, Intent } from '@blueprintjs/core';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Card, Elevation, Button, Tag, Spinner, Icon, Dialog, Intent, NonIdealState } from '@blueprintjs/core';
 import ExecutorService from '../../services/Executor';
 import ServerService from '../../services/Server';
+import TaskService, { QueueTask } from '../../services/TaskService';
 import { CommandInfo } from '../../providers/IInstallerProvider';
-import styles from './style.module.css';
 import { useTranslation } from 'react-i18next';
 
-interface QueueItem {
-    id: string;
-    name: string;
-    status: 'waiting' | 'processing' | 'completed' | 'failed';
-    progress: number;
-    createdAt: Date;
-    type: string;
-    priority: number;
-}
-
 interface QueueProps {
-    items?: QueueItem[];
+    items?: QueueTask[];
     onRemoveItem?: (id: string) => void;
     onPauseItem?: (id: string) => void;
     onResumeItem?: (id: string) => void;
 }
 
-const Queue: React.FC<QueueProps> = ({
-                                         items = [],
-                                         onRemoveItem,
-                                         onPauseItem,
-                                         onResumeItem
-                                     }) => {
+const Queue: React.FC<QueueProps> = ({ items: initialItems }) => {
     const { t } = useTranslation();
-    const [visibleItems, setVisibleItems] = useState<QueueItem[]>([]);
+    const [items, setItems] = useState<QueueTask[]>(initialItems ?? []);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
     const [executorStatus, setExecutorStatus] = useState<CommandInfo | null>(null);
     const [serverStatus, setServerStatus] = useState<CommandInfo | null>(null);
     const [isRestartDialogOpen, setIsRestartDialogOpen] = useState(false);
     const [restartType, setRestartType] = useState<'server' | 'executor' | null>(null);
     const [isRestarting, setIsRestarting] = useState(false);
-    const containerRef = useRef<HTMLDivElement>(null);
-    const itemHeight = 80; // 每个队列项的估计高度
-    const bufferSize = 5; // 上下缓冲区的项目数量
+    const taskService = useRef(TaskService.getInstance());
 
-    // 获取服务状态
-    useEffect(() => {
-        const fetchStatus = async () => {
-            try {
-                // 获取执行器状态
-                const executorResult = await ExecutorService.getInstance().getExecutorStatus();
-                setExecutorStatus(executorResult);
-
-                // 获取服务器状态
-                const serverResult = await ServerService.getInstance().getServerStatus();
-                setServerStatus(serverResult);
-            } catch (error) {
-                console.error('获取服务状态时出错:', error);
-            }
-        };
-
-        // 初始获取状态
-        fetchStatus();
-
-        // 设置定时器，每 30 秒更新一次状态
-        const intervalId = setInterval(fetchStatus, 30000);
-
-        return () => {
-            clearInterval(intervalId);
-        };
+    const loadTasks = useCallback(async () => {
+        try {
+            const tasks = await taskService.current.fetchTasks();
+            setItems(tasks);
+            setError(null);
+        } catch (err) {
+            console.error('获取任务列表失败:', err);
+            setError(err instanceof Error ? err.message : '获取任务列表失败');
+        } finally {
+            setLoading(false);
+        }
     }, []);
 
-    // 根据滚动位置计算可见项
-    const calculateVisibleItems = () => {
-        if (!containerRef.current) return;
-
-        const container = containerRef.current;
-        const scrollTop = container.scrollTop;
-        const containerHeight = container.clientHeight;
-
-        // 计算可见范围内的第一个和最后一个项目的索引
-        const startIndex = Math.max(0, Math.floor(scrollTop / itemHeight) - bufferSize);
-        const endIndex = Math.min(
-            items.length - 1,
-            Math.ceil((scrollTop + containerHeight) / itemHeight) + bufferSize
-        );
-
-        // 设置可见项
-        setVisibleItems(items.slice(startIndex, endIndex + 1));
-    };
-
-    // 监听滚动事件
     useEffect(() => {
-        const container = containerRef.current;
-        if (container) {
-            container.addEventListener('scroll', calculateVisibleItems);
-            // 初始计算
-            calculateVisibleItems();
+        loadTasks();
 
-            return () => {
-                container.removeEventListener('scroll', calculateVisibleItems);
-            };
-        }
-    }, [items]);
+        // websocket 实时更新
+        const unsubscribe = taskService.current.subscribe((updatedTask) => {
+            setItems(prev => {
+                const exists = prev.some(item => item.id === updatedTask.id);
+                if (exists) {
+                    return prev.map(item => item.id === updatedTask.id ? updatedTask : item);
+                }
+                return [updatedTask, ...prev];
+            });
+        });
 
-    // 当项目列表变化时重新计算
-    useEffect(() => {
-        calculateVisibleItems();
-    }, [items]);
+        // 轮询兜底（生图任务状态由调度器维护）
+        const pollId = setInterval(loadTasks, 5000);
 
-    // 获取状态对应的标签颜色
-    const getStatusColor = (status: string) => {
-        switch (status) {
-            case 'waiting': return 'blue';
-            case 'processing': return 'orange';
-            case 'completed': return 'green';
-            case 'failed': return 'red';
-            default: return 'gray';
-        }
-    };
+        const fetchStatus = async () => {
+            try {
+                const executorResult = await ExecutorService.getInstance().getExecutorStatus();
+                setExecutorStatus(executorResult);
+                const serverResult = await ServerService.getInstance().getServerStatus();
+                setServerStatus(serverResult);
+            } catch (err) {
+                console.error('获取服务状态时出错:', err);
+            }
+        };
+        fetchStatus();
+        const statusId = setInterval(fetchStatus, 30000);
 
-    // 获取状态对应的中文描述
-    const getStatusText = (status: string) => {
-        return t(`queue.status.${status}`);
-    };
+        return () => {
+            unsubscribe();
+            clearInterval(pollId);
+            clearInterval(statusId);
+        };
+    }, [loadTasks]);
 
-    // 重启服务
     const handleRestartService = async () => {
         if (!restartType) return;
-
         setIsRestarting(true);
         try {
-
-            // 根据类型调用相应的重启方法
             if (restartType === 'server') {
                 const newStatus = await ServerService.getInstance().restartServer();
                 setServerStatus(newStatus);
@@ -136,8 +86,6 @@ const Queue: React.FC<QueueProps> = ({
                 const newStatus = await ExecutorService.getInstance().restartExecutor();
                 setExecutorStatus(newStatus);
             }
-
-            console.log(`重启${restartType === 'server' ? '服务器' : '执行器'}`);
         } catch (error) {
             console.error(`重启${restartType === 'server' ? '服务器' : '执行器'}时出错:`, error);
         } finally {
@@ -146,18 +94,13 @@ const Queue: React.FC<QueueProps> = ({
         }
     };
 
-    // 获取服务状态图标
     const getServiceStatusIcon = (status: CommandInfo | null, type: 'server' | 'executor') => {
         if (!status) return <Icon icon="circle" intent="none" />;
-
-        // 检查消息中是否包含"运行中"或"启动成功"
         const isRunning = status.message.includes('运行中') || status.message.includes('启动成功');
-
         const handleRestartClick = () => {
             setRestartType(type);
             setIsRestartDialogOpen(true);
         };
-
         if (isRunning) {
             return <Icon icon="circle" intent="success" onClick={handleRestartClick} style={{ cursor: 'pointer' }} />;
         } else if (status.message.includes('未在运行中')) {
@@ -165,6 +108,40 @@ const Queue: React.FC<QueueProps> = ({
         } else {
             return <Icon icon="circle" intent="danger" />;
         }
+    };
+
+    const getStatusColor = (status: QueueTask['status']) => {
+        switch (status) {
+            case 'waiting': return 'blue';
+            case 'processing': return 'orange';
+            case 'completed': return 'green';
+            case 'failed': return 'red';
+            case 'cancelled': return 'gray';
+            default: return 'gray';
+        }
+    };
+
+    const getStatusText = (status: QueueTask['status']) => {
+        return t(`queue.status.${status}`);
+    };
+
+    const handleRemove = async (id: string) => {
+        const success = await taskService.current.removeTask(id);
+        if (success) {
+            setItems(prev => prev.filter(item => item.id !== id));
+        }
+    };
+
+    const handleCancel = async (id: string) => {
+        const success = await taskService.current.cancelTask(id);
+        if (success) {
+            setItems(prev => prev.map(item => item.id === id ? { ...item, status: 'cancelled', progress: 0 } : item));
+        }
+    };
+
+    const handleClearCompleted = async () => {
+        await taskService.current.clearCompleted();
+        await loadTasks();
     };
 
     return (
@@ -182,23 +159,18 @@ const Queue: React.FC<QueueProps> = ({
                         </div>
                     </div>
                 </div>
-                <div style={{ display: 'flex', gap: '2px' }}>
-                    <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-                        <div className={styles.toggleButton}>
-                            <Icon icon="play" size={20} />
-                        </div>
-                        {/*<Button text="继续" intent="success" icon="play" variant="solid" />*/}
-                        {/*<Button text="暂停" intent="warning" icon="pause" variant="solid" />*/}
-                    </div>
-
-                </div>
-            </div>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
-                <Button text={t('queue.clearCache')} icon="trash" variant="solid" />
-                <Button text={t('queue.disableCache')} intent="danger" icon="disable" variant="solid" />
             </div>
 
-            {/* 重启服务确认对话框 */}
+            <div style={{ display: 'flex', gap: '8px', padding: '8px 10px', borderBottom: '1px solid #e1e8ed' }}>
+                <Button
+                    text={t('queue.clearCompleted')}
+                    icon="trash"
+                    variant="solid"
+                    onClick={handleClearCompleted}
+                    disabled={items.length === 0}
+                />
+            </div>
+
             <Dialog
                 isOpen={isRestartDialogOpen}
                 onClose={() => setIsRestartDialogOpen(false)}
@@ -221,107 +193,77 @@ const Queue: React.FC<QueueProps> = ({
                 </div>
             </Dialog>
 
-            <div
-                ref={containerRef}
-                style={{
-                    flex: 1,
-                    overflowY: 'auto',
-                    position: 'relative',
-                    height: 'calc(100vh - 150px)'
-                }}
-            >
-                {/* 创建一个占位容器，确保滚动条的高度正确 */}
-                <div style={{ height: `${items.length * itemHeight}px` }}>
-                    {/* 只渲染可见的项目 */}
-                    {visibleItems.map((item, _) => {
-                        // 计算项目在整个列表中的位置
-                        const itemIndex = items.findIndex(i => i.id === item.id);
-
-                        return (
-                            <Card
-                                key={item.id}
-                                elevation={Elevation.ONE}
-                                style={{
-                                    margin: '8px',
-                                    padding: '10px',
-                                    position: 'absolute',
-                                    top: `${itemIndex * itemHeight}px`,
-                                    left: 0,
-                                    right: 0,
-                                    height: `${itemHeight - 16}px`, // 减去margin
-                                }}
-                            >
-                                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                                    <div>
-                                        <h3 style={{ margin: '0 0 5px 0' }}>{item.name}</h3>
-                                        <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
-                                            <Tag intent={getStatusColor(item.status) as any}>
-                                                {getStatusText(item.status)}
-                                            </Tag>
-                                            <span style={{ fontSize: '0.9em', color: '#666' }}>
-                        {item.type} · {t('queue.priority', { priority: item.priority })}
-                      </span>
-                                            <span style={{ fontSize: '0.9em', color: '#666' }}>
-                        {item.createdAt.toLocaleString()}
-                      </span>
-                                        </div>
-                                    </div>
-
-                                    <div style={{ display: 'flex', gap: '5px' }}>
-                                        {item.status === 'processing' && (
-                                            <Button
-                                                small
-                                                icon="pause"
-                                                variant="minimal"
-                                                onClick={() => onPauseItem?.(item.id)}
-                                                title="暂停"
-                                            />
-                                        )}
-                                        {item.status === 'waiting' && (
-                                            <Button
-                                                small
-                                                icon="play"
-                                                variant="minimal"
-                                                onClick={() => onResumeItem?.(item.id)}
-                                                title="开始"
-                                            />
-                                        )}
-                                        <Button
-                                            small
-                                            icon="cross"
-                                            variant="minimal"
-                                            intent="danger"
-                                            onClick={() => onRemoveItem?.(item.id)}
-                                            title="移除"
-                                        />
+            <div style={{ flex: 1, overflowY: 'auto', padding: '8px' }}>
+                {loading ? (
+                    <div style={{ textAlign: 'center', padding: '40px' }}>
+                        <Spinner />
+                    </div>
+                ) : error && items.length === 0 ? (
+                    <NonIdealState icon="error" title={t('queue.loadError')} description={error} />
+                ) : items.length === 0 ? (
+                    <NonIdealState icon="inbox" title={t('queue.empty')} />
+                ) : (
+                    items.map(item => (
+                        <Card key={item.id} elevation={Elevation.ONE} style={{ marginBottom: '8px', padding: '10px' }}>
+                            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                                <div>
+                                    <h3 style={{ margin: '0 0 5px 0' }}>{item.name}</h3>
+                                    <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                                        <Tag intent={getStatusColor(item.status) as any}>
+                                            {getStatusText(item.status)}
+                                        </Tag>
+                                        <span style={{ fontSize: '0.9em', color: '#666' }}>
+                                            {t(`queue.kind.${item.kind}`)}
+                                        </span>
+                                        <span style={{ fontSize: '0.9em', color: '#666' }}>
+                                            {new Date(item.createdAt * 1000).toLocaleString()}
+                                        </span>
                                     </div>
                                 </div>
+                                <div style={{ display: 'flex', gap: '5px' }}>
+                                    {(item.status === 'waiting' || item.status === 'processing') && (
+                                        <Button
+                                            small
+                                            icon="stop"
+                                            variant="minimal"
+                                            intent={Intent.WARNING}
+                                            onClick={() => handleCancel(item.id)}
+                                            title={t('queue.actions.cancel')}
+                                        />
+                                    )}
+                                    <Button
+                                        small
+                                        icon="cross"
+                                        variant="minimal"
+                                        intent="danger"
+                                        onClick={() => handleRemove(item.id)}
+                                        title={t('queue.actions.remove')}
+                                    />
+                                </div>
+                            </div>
 
-                                {item.status === 'processing' && (
-                                    <div style={{
-                                        marginTop: '10px',
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        gap: '10px'
-                                    }}>
-                                        <div style={{ flex: 1, height: '6px', backgroundColor: '#e1e8ed', borderRadius: '3px' }}>
-                                            <div
-                                                style={{
-                                                    width: `${item.progress}%`,
-                                                    height: '100%',
-                                                    backgroundColor: '#2b95d6',
-                                                    borderRadius: '3px'
-                                                }}
-                                            />
-                                        </div>
-                                        <Spinner size={16} />
-                                        <span>{item.progress}%</span>
+                            {item.status === 'processing' && (
+                                <div style={{ marginTop: '10px', display: 'flex', alignItems: 'center', gap: '10px' }}>
+                                    <div style={{ flex: 1, height: '6px', backgroundColor: '#e1e8ed', borderRadius: '3px' }}>
+                                        <div
+                                            style={{
+                                                width: `${item.progress}%`,
+                                                height: '100%',
+                                                backgroundColor: '#2b95d6',
+                                                borderRadius: '3px',
+                                                transition: 'width 0.3s'
+                                            }}
+                                        />
                                     </div>
-                                )}
-                            </Card>
-                        );
-                    })}
-                </div>
+                                    <span>{item.progress}%</span>
+                                </div>
+                            )}
+                            {item.status === 'failed' && item.error && (
+                                <div style={{ marginTop: '8px', color: 'red', fontSize: '0.9em' }}>{item.error}</div>
+                            )}
+                        </Card>
+                    ))
+                )}
             </div>
         </div>
     );

--- a/desktop/src/i18n/locales/en-us.json
+++ b/desktop/src/i18n/locales/en-us.json
@@ -98,6 +98,17 @@
         "server": "Server",
         "clearCache": "Clear Cache",
         "disableCache": "Disable Cache",
+        "clearCompleted": "Clear Completed",
+        "loadError": "Failed to load tasks",
+        "empty": "No tasks",
+        "actions": {
+            "cancel": "Cancel Task",
+            "remove": "Remove Task"
+        },
+        "kind": {
+            "download": "Download",
+            "generation": "Generation"
+        },
         "restart": {
             "title": "Restart {{type}}",
             "confirm": "Are you sure you want to restart the {{type}}?",
@@ -110,7 +121,8 @@
             "waiting": "Waiting",
             "processing": "Processing",
             "completed": "Completed",
-            "failed": "Failed"
+            "failed": "Failed",
+            "cancelled": "Cancelled"
         }
     }
 }

--- a/desktop/src/i18n/locales/zh-cn.json
+++ b/desktop/src/i18n/locales/zh-cn.json
@@ -98,6 +98,17 @@
         "server": "服务器",
         "clearCache": "清除缓存",
         "disableCache": "禁用缓存",
+        "clearCompleted": "清除已完成",
+        "loadError": "加载任务失败",
+        "empty": "暂无任务",
+        "actions": {
+            "cancel": "取消任务",
+            "remove": "移除任务"
+        },
+        "kind": {
+            "download": "下载任务",
+            "generation": "生图任务"
+        },
         "restart": {
             "title": "重启{{type}}",
             "confirm": "确定要重启{{type}}吗？",
@@ -110,7 +121,8 @@
             "waiting": "等待中",
             "processing": "处理中",
             "completed": "已完成",
-            "failed": "失败"
+            "failed": "失败",
+            "cancelled": "已取消"
         }
     }
 }

--- a/desktop/src/services/TaskService.ts
+++ b/desktop/src/services/TaskService.ts
@@ -1,0 +1,96 @@
+import GlobalStateManager from './GlobalState';
+
+export interface QueueTask {
+    id: string;
+    kind: 'download' | 'generation';
+    name: string;
+    status: 'waiting' | 'processing' | 'completed' | 'failed' | 'cancelled';
+    progress: number;
+    createdAt: number;
+    error?: string | null;
+    meta?: Record<string, any>;
+}
+
+/**
+ * 任务队列服务：封装 /api/tasks 的 REST 接口与 websocket task_update 订阅。
+ */
+class TaskService {
+    private static instance: TaskService | null = null;
+    private ws: WebSocket | null = null;
+    private listeners: ((task: QueueTask) => void)[] = [];
+
+    public static getInstance(): TaskService {
+        if (!TaskService.instance) {
+            TaskService.instance = new TaskService();
+        }
+        return TaskService.instance;
+    }
+
+    private getBaseUrl(): string {
+        const rootState = GlobalStateManager.getInstance().getRootState();
+        const host = rootState?.host || 'localhost';
+        const port = rootState?.port || 7422;
+        return `http://${host}:${port}`;
+    }
+
+    public async fetchTasks(): Promise<QueueTask[]> {
+        const response = await fetch(`${this.getBaseUrl()}/api/tasks`);
+        if (!response.ok) {
+            throw new Error(`Failed to fetch tasks: ${response.status}`);
+        }
+        const data = await response.json();
+        return data.items || [];
+    }
+
+    public async removeTask(id: string): Promise<boolean> {
+        const response = await fetch(`${this.getBaseUrl()}/api/tasks/${encodeURIComponent(id)}`, {
+            method: 'DELETE'
+        });
+        const data = await response.json();
+        return data.success === true;
+    }
+
+    public async cancelTask(id: string): Promise<boolean> {
+        const response = await fetch(`${this.getBaseUrl()}/api/tasks/${encodeURIComponent(id)}/cancel`, {
+            method: 'POST'
+        });
+        const data = await response.json();
+        return data.success === true;
+    }
+
+    public async clearCompleted(): Promise<void> {
+        await fetch(`${this.getBaseUrl()}/api/tasks/clear`, {
+            method: 'POST'
+        });
+    }
+
+    public subscribe(callback: (task: QueueTask) => void): () => void {
+        this.listeners.push(callback);
+        this.ensureSocket();
+        return () => {
+            this.listeners = this.listeners.filter(listener => listener !== callback);
+        };
+    }
+
+    private ensureSocket(): void {
+        if (this.ws) return;
+        const wsUrl = this.getBaseUrl().replace(/^http/, 'ws') + '/ws';
+        const socket = new WebSocket(wsUrl);
+        socket.onmessage = (event) => {
+            try {
+                const data = JSON.parse(event.data);
+                if (data.type === 'task_update' && data.task) {
+                    this.listeners.forEach(listener => listener(data.task as QueueTask));
+                }
+            } catch (error) {
+                console.error('解析任务推送失败:', error);
+            }
+        };
+        socket.onclose = () => {
+            this.ws = null;
+        };
+        this.ws = socket;
+    }
+}
+
+export default TaskService;

--- a/desktop/src/stories/QueuePage.stories.tsx
+++ b/desktop/src/stories/QueuePage.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import Queue from '../components/Queue';
+import { QueueTask } from '../services/TaskService';
 
 const meta: Meta<typeof Queue> = {
   title: 'Components/Queue',
@@ -14,19 +15,22 @@ type Story = StoryObj<typeof Queue>;
 
 // 生成测试数据
 const generateQueueItems = (count: number) => {
-  const items = [];
-  const statuses: ('waiting' | 'processing' | 'completed' | 'failed')[] = ['waiting', 'processing', 'completed', 'failed'];
+  const items: QueueTask[] = [];
+  const statuses: QueueTask['status'][] = ['waiting', 'processing', 'completed', 'failed', 'cancelled'];
   const types = ['安装', '更新', '卸载', '修复'];
   
   for (let i = 0; i < count; i++) {
     items.push({
       id: `item-${i}`,
       name: `测试任务 ${i + 1}`,
+      kind: i % 2 === 0 ? 'download' : 'generation',
       status: statuses[i % statuses.length],
       progress: Math.floor(Math.random() * 100),
-      createdAt: new Date(Date.now() - Math.random() * 10000000000),
-      type: types[i % types.length],
-      priority: Math.floor(Math.random() * 5) + 1,
+      createdAt: (Date.now() - Math.random() * 10000000000) / 1000,
+      meta: {
+        type: types[i % types.length],
+        priority: Math.floor(Math.random() * 5) + 1,
+      },
     });
   }
   return items;

--- a/server/app.py
+++ b/server/app.py
@@ -16,10 +16,12 @@ from server.routes import (
     file_routes,
     model_routes,
     script_routes,
+    task_routes,
     ui_state_routes,
     websocket_routes,
 )
 from server.script_service import ScriptService
+from server.task_service import TaskService
 from server.websocket_service import WebSocketService
 from ss_executor.scheduler import TaskScheduler
 
@@ -30,6 +32,7 @@ def create_app(
     scheduler=None,
     script_service=None,
     websocket_service=None,
+    task_service=None,
 ) -> FastAPI:
     """组装 FastAPI 应用。
 
@@ -46,6 +49,7 @@ def create_app(
     script_service = script_service or ScriptService(scheduler)
     model_service = model_service or ModelService(resources_dir)
     websocket_service = websocket_service or WebSocketService()
+    task_service = task_service or TaskService()
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -66,6 +70,7 @@ def create_app(
     app.state.scheduler = scheduler
     app.state.script_service = script_service
     app.state.websocket_service = websocket_service
+    app.state.task_service = task_service
     app.state.resources_dir = resources_dir
     app.state.settings_path = settings_path
 
@@ -84,6 +89,7 @@ def create_app(
     app.include_router(ui_state_routes.router)
     app.include_router(extension_routes.router)
     app.include_router(websocket_routes.router)
+    app.include_router(task_routes.router)
 
     # 对于静态数据的请求，使用文件资源管理器
     settings = config_service.get_settings()

--- a/server/routes/task_routes.py
+++ b/server/routes/task_routes.py
@@ -1,0 +1,220 @@
+import asyncio
+import os
+import time
+import uuid
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Body, Request
+from fastapi.responses import JSONResponse
+
+router = APIRouter()
+
+
+def _scheduler_task_to_dict(task) -> Dict[str, Any]:
+    """把 ss_executor.Task 映射为统一的队列任务格式。"""
+    status_map = {
+        "pending": "waiting",
+        "running": "processing",
+        "completed": "completed",
+        "failed": "failed",
+        "cancelled": "cancelled",
+    }
+    status = getattr(task, "status", None)
+    status_value = status.value if hasattr(status, "value") else str(status or "pending")
+    return {
+        "id": task.task_id,
+        "kind": "generation",
+        "name": f"{task.callable} · {os.path.basename(task.script)}",
+        "status": status_map.get(status_value, status_value),
+        "progress": 100 if status_value == "completed" else 0,
+        "createdAt": time.time(),
+        "error": task.error,
+        "meta": {"script": task.script, "callable": task.callable},
+    }
+
+
+async def _start_download(
+    request: Request,
+    record_id: str,
+    kind: str,
+    name: str,
+    url: Optional[str],
+    repo_id: Optional[str],
+) -> str:
+    """创建一个下载任务并后台执行，返回 request_uuid。"""
+    task_service = request.app.state.task_service
+    model_service = request.app.state.model_service
+    websocket_service = request.app.state.websocket_service
+    resources_dir = request.app.state.resources_dir
+
+    request_uuid = str(uuid.uuid4())
+    local_dir = os.path.join(resources_dir, "downloads", record_id)
+    os.makedirs(local_dir, exist_ok=True)
+    loop = asyncio.get_running_loop()
+
+    async def broadcast_task(rid: str) -> None:
+        record = task_service.get(rid)
+        if record is not None:
+            await websocket_service.broadcast({"type": "task_update", "task": record.to_dict()})
+
+    def progress_callback(
+        client_id: str,
+        request_uuid: str,
+        callback_data: Dict[str, Any],
+    ) -> None:
+        progress_data = callback_data.get("download_progress") or callback_data.get("download_error")
+        error = callback_data.get("download_error")
+        if isinstance(progress_data, dict):
+            progress = round(float(progress_data.get("progress") or 0))
+            task_service.update(
+                record_id,
+                progress=progress,
+                status="processing",
+                error=str(error) if error else None,
+            )
+            loop.call_soon_threadsafe(
+                asyncio.create_task, broadcast_task(record_id)
+            )
+        websocket_service.send_callback(client_id, request_uuid, callback_data)
+
+    def hf_progress_callback(
+        client_id: str,
+        request_uuid: str,
+        callback_name: str,
+        callback_data: Dict[str, Any],
+    ) -> None:
+        progress_callback(client_id, request_uuid, {callback_name: callback_data})
+
+    def finish_callback(
+        client_id: str,
+        request_uuid: str,
+        extra_data: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        extra = extra_data or {}
+        error = extra.get("error")
+        task_service.update(
+            record_id,
+            status="failed" if error else "completed",
+            progress=0 if error else 100,
+            error=str(error) if error else None,
+        )
+        loop.call_soon_threadsafe(
+            asyncio.create_task, broadcast_task(record_id)
+        )
+        websocket_service.send_finish(client_id, request_uuid, extra)
+
+    await _notify_task_started(task_service, websocket_service, record_id)
+
+    if url and url.startswith(("http://", "https://")):
+        await model_service.download_file(
+            url=url,
+            local_dir=local_dir,
+            client_id="task",
+            request_uuid=request_uuid,
+            callback=progress_callback,
+            finish_callback=finish_callback,
+        )
+    elif repo_id:
+        await model_service.hf_download(
+            repo_id=repo_id,
+            local_dir=local_dir,
+            client_id="task",
+            request_uuid=request_uuid,
+            callback=hf_progress_callback,
+            finish_callback=finish_callback,
+        )
+    else:
+        task_service.update(record_id, status="failed", error="url 或 repo_id 必须提供其一")
+    return request_uuid
+
+
+async def _notify_task_started(task_service, websocket_service, record_id: str) -> None:
+    record = task_service.get(record_id)
+    if record is not None:
+        await websocket_service.broadcast({"type": "task_update", "task": record.to_dict()})
+
+
+@router.get("/api/tasks")
+async def list_tasks(
+    request: Request,
+    kind: Optional[str] = None,
+    status: Optional[str] = None,
+):
+    """列出任务：下载任务来自 TaskService，生图任务来自执行器调度器。"""
+    task_service = request.app.state.task_service
+    scheduler = request.app.state.scheduler
+
+    items = [r.to_dict() for r in task_service.list(kind=kind, status=status)]
+    if kind is None or kind == "generation":
+        scheduler_tasks = getattr(scheduler, "tasks", {}) or {}
+        for task in scheduler_tasks.values():
+            item = _scheduler_task_to_dict(task)
+            if status and item["status"] != status:
+                continue
+            items.append(item)
+    return {"items": items}
+
+
+@router.post("/api/tasks/download")
+async def create_download_task(
+    request: Request,
+    kind: str = Body("url", embed=True),
+    name: str = Body(..., embed=True),
+    url: Optional[str] = Body(None, embed=True),
+    repo_id: Optional[str] = Body(None, embed=True),
+):
+    """创建下载任务并后台执行（支持 HTTP(S) 直链与 HuggingFace 仓库）。"""
+    task_service = request.app.state.task_service
+    record = task_service.add("download", name, {"kind": kind, "url": url, "repo_id": repo_id})
+    request_uuid = await _start_download(request, record.id, kind, name, url, repo_id)
+    return {
+        "type": "start",
+        "task_id": record.id,
+        "request_uuid": request_uuid,
+    }
+
+
+@router.delete("/api/tasks/{task_id}")
+async def remove_task(request: Request, task_id: str):
+    task_service = request.app.state.task_service
+    removed = task_service.remove(task_id)
+    return {"success": removed}
+
+
+@router.post("/api/tasks/clear")
+async def clear_completed_tasks(request: Request):
+    task_service = request.app.state.task_service
+    count = task_service.clear_completed()
+    return {"success": True, "removed": count}
+
+
+@router.post("/api/tasks/{task_id}/cancel")
+async def cancel_task(request: Request, task_id: str):
+    task_service = request.app.state.task_service
+    websocket_service = request.app.state.websocket_service
+    cancelled = task_service.cancel(task_id)
+    if cancelled:
+        record = task_service.get(task_id)
+        if record is not None:
+            await websocket_service.broadcast({"type": "task_update", "task": record.to_dict()})
+    return {"success": cancelled}
+
+
+@router.post("/api/tasks/{task_id}/retry")
+async def retry_task(request: Request, task_id: str):
+    """重试失败的下载任务：按原 meta 重新创建任务。"""
+    task_service = request.app.state.task_service
+    record = task_service.get(task_id)
+    if record is None:
+        return JSONResponse({"error": "Task not found"}, status_code=404)
+    meta = record.meta or {}
+    new_record = task_service.add("download", record.name, meta)
+    await _start_download(
+        request,
+        new_record.id,
+        meta.get("kind", "url"),
+        record.name,
+        meta.get("url"),
+        meta.get("repo_id"),
+    )
+    return {"success": True, "task_id": new_record.id}

--- a/server/task_service.py
+++ b/server/task_service.py
@@ -1,0 +1,99 @@
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class TaskRecord:
+    """统一任务记录：下载任务与生图任务共用。"""
+
+    id: str
+    kind: str  # download | generation
+    name: str
+    status: str = "waiting"  # waiting | processing | completed | failed | cancelled
+    progress: int = 0
+    created_at: float = field(default_factory=time.time)
+    error: Optional[str] = None
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "kind": self.kind,
+            "name": self.name,
+            "status": self.status,
+            "progress": self.progress,
+            "createdAt": self.created_at,
+            "error": self.error,
+            "meta": self.meta,
+        }
+
+
+class TaskService:
+    """线程安全的任务注册表（同步方法，便于在下载线程中直接更新）。"""
+
+    def __init__(self) -> None:
+        self._tasks: Dict[str, TaskRecord] = {}
+        self._lock = threading.Lock()
+
+    def add(self, kind: str, name: str, meta: Optional[Dict[str, Any]] = None) -> TaskRecord:
+        record = TaskRecord(
+            id=str(uuid.uuid4()),
+            kind=kind,
+            name=name,
+            meta=meta or {},
+        )
+        with self._lock:
+            self._tasks[record.id] = record
+        return record
+
+    def get(self, task_id: str) -> Optional[TaskRecord]:
+        with self._lock:
+            return self._tasks.get(task_id)
+
+    def update(self, task_id: str, **changes: Any) -> Optional[TaskRecord]:
+        with self._lock:
+            record = self._tasks.get(task_id)
+            if record is None:
+                return None
+            for key, value in changes.items():
+                if hasattr(record, key):
+                    setattr(record, key, value)
+            return record
+
+    def list(self, kind: Optional[str] = None, status: Optional[str] = None) -> List[TaskRecord]:
+        with self._lock:
+            records = list(self._tasks.values())
+        if kind:
+            records = [r for r in records if r.kind == kind]
+        if status:
+            records = [r for r in records if r.status == status]
+        return sorted(records, key=lambda r: r.created_at, reverse=True)
+
+    def remove(self, task_id: str) -> bool:
+        with self._lock:
+            return self._tasks.pop(task_id, None) is not None
+
+    def cancel(self, task_id: str) -> bool:
+        with self._lock:
+            record = self._tasks.get(task_id)
+            if record is None:
+                return False
+            if record.status in ("completed", "failed", "cancelled"):
+                return False
+            record.status = "cancelled"
+            record.progress = 0
+            return True
+
+    def clear_completed(self) -> int:
+        with self._lock:
+            keys = [
+                k
+                for k, r in self._tasks.items()
+                if r.status in ("completed", "failed", "cancelled")
+            ]
+            for key in keys:
+                del self._tasks[key]
+            return len(keys)

--- a/server/websocket_service.py
+++ b/server/websocket_service.py
@@ -29,6 +29,15 @@ class WebSocketService:
                 await self.clients[client_id].send_text(json.dumps(message))
             except Exception as e:
                 print(f"Error sending message to client {client_id}: {e}")
+
+    async def broadcast(self, message: Dict[str, Any]) -> None:
+        """向所有在线客户端广播消息。"""
+        payload = json.dumps(message)
+        for client_id in list(self.clients.keys()):
+            try:
+                await self.clients[client_id].send_text(payload)
+            except Exception as e:
+                print(f"Error broadcasting to client {client_id}: {e}")
     
     def send_callback(self, client_id: str, request_uuid: str, callback_data: Dict[str, Any]) -> None:
         message = WebSocketCallback(type="callback", request_uuid=request_uuid, **callback_data)


### PR DESCRIPTION
对应 v0.2 Roadmap issue #17「任务队列」：后端统一任务注册表 + /api/tasks REST API + websocket task_update 推送；前端 Queue 页接入真实数据（下载+生图）、进度条与取消/移除/清除操作。desktop build 与 /api/tasks 接口验证通过。