### PR TITLE
feat(queue): 模型安装页下载接入统一任务队列

### DIFF
--- a/desktop/src/components/ModelAdding/HuggingfaceModels/index.tsx
+++ b/desktop/src/components/ModelAdding/HuggingfaceModels/index.tsx
@@ -1,11 +1,10 @@
-import React, {useRef, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import { Button, InputGroup, Spinner, Tabs, Tab, NonIdealState, Tag, Icon, CompoundTag, ProgressBar } from '@blueprintjs/core';
 import axios from 'axios';
 import HuggingfaceLogo from './logo_huggingface.svg'
 import ModelLogo from './logo_model.svg'
 import styles from './style.module.css'
-import { Message } from 'ssui_components';
-import GlobalStateManager from '../../../services/GlobalState.ts';
+import TaskService from '../../../services/TaskService';
 
 export interface HuggingfaceModel {
     id: string;
@@ -38,15 +37,30 @@ const HuggingfaceModels: React.FC<HuggingfaceModelsProps> = () => {
     const [selectedType, setSelectedType] = useState<string>('all');
     const [hasSearched, setHasSearched] = useState(false);
     const [downloading, setDownloading] = useState<{ [id: string]: number }>({});
-    const messageRef = useRef<Message | null>(null);
+    const taskService = useRef(TaskService.getInstance());
+    const taskIds = useRef<{ [modelId: string]: string }>({});
 
-    const getMessage = () => {
-        if (!messageRef.current) {
-            const rootState = GlobalStateManager.getInstance().getRootState();
-            messageRef.current = new Message(rootState?.host || 'localhost', rootState?.port || 7422);
-        }
-        return messageRef.current;
-    };
+    useEffect(() => {
+        // 通过任务队列的 task_update 推送更新下载进度
+        const unsubscribe = taskService.current.subscribe((task) => {
+            if (task.kind !== 'download') return;
+            for (const [modelId, taskId] of Object.entries(taskIds.current)) {
+                if (taskId === task.id) {
+                    if (task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled') {
+                        delete taskIds.current[modelId];
+                        setDownloading(prev => {
+                            const next = { ...prev };
+                            delete next[modelId];
+                            return next;
+                        });
+                    } else {
+                        setDownloading(prev => ({ ...prev, [modelId]: task.progress }));
+                    }
+                }
+            }
+        });
+        return unsubscribe;
+    }, []);
 
     const searchModels = async () => {
         if (!inputValue.trim()) return;
@@ -104,24 +118,15 @@ const HuggingfaceModels: React.FC<HuggingfaceModelsProps> = () => {
         const modelId = model.modelId || model.id;
         setDownloading(prev => ({ ...prev, [model.id]: 0 }));
         try {
-            await getMessage().post(
-                'api/hf_download',
-                { repo_id: modelId },
-                {
-                    download_progress: (data: any) => {
-                        const progress = Math.round(data?.progress ?? 0);
-                        setDownloading(prev => ({ ...prev, [model.id]: progress }));
-                    }
-                }
+            const taskId = await taskService.current.createDownloadTask(
+                'huggingface',
+                modelId,
+                undefined,
+                modelId
             );
+            taskIds.current[model.id] = taskId;
         } catch (error) {
             console.error('HuggingFace 模型下载失败:', error);
-        } finally {
-            setDownloading(prev => {
-                const next = { ...prev };
-                delete next[model.id];
-                return next;
-            });
         }
     };
 

--- a/desktop/src/components/ModelAdding/PresetModels/index.tsx
+++ b/desktop/src/components/ModelAdding/PresetModels/index.tsx
@@ -2,8 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Button, Icon, Tooltip, ProgressBar } from '@blueprintjs/core';
 import styles from './style.module.css';
 import { useTranslation } from 'react-i18next';
-import { Message } from 'ssui_components';
-import GlobalStateManager from '../../../services/GlobalState.ts';
+import TaskService from '../../../services/TaskService';
 
 interface PresetModel {
     id: string;
@@ -43,15 +42,8 @@ export const PresetModels: React.FC<PresetModelsProps> = ({ onModelSelect }) => 
     const [loading, setLoading] = useState(false);
     const [loadError, setLoadError] = useState<string | null>(null);
     const [downloading, setDownloading] = useState<{ [id: string]: number }>({});
-    const messageRef = useRef<Message | null>(null);
-
-    const getMessage = () => {
-        if (!messageRef.current) {
-            const rootState = GlobalStateManager.getInstance().getRootState();
-            messageRef.current = new Message(rootState?.host || 'localhost', rootState?.port || 7422);
-        }
-        return messageRef.current;
-    };
+    const taskService = useRef(TaskService.getInstance());
+    const taskIds = useRef<{ [modelId: string]: string }>({});
 
     useEffect(() => {
         const fetchPresets = async () => {
@@ -76,28 +68,42 @@ export const PresetModels: React.FC<PresetModelsProps> = ({ onModelSelect }) => 
         fetchPresets();
     }, []);
 
+    useEffect(() => {
+        // 通过任务队列的 task_update 推送更新下载进度
+        const unsubscribe = taskService.current.subscribe((task) => {
+            if (task.kind !== 'download') return;
+            for (const [modelId, taskId] of Object.entries(taskIds.current)) {
+                if (taskId === task.id) {
+                    if (task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled') {
+                        delete taskIds.current[modelId];
+                        setDownloading(prev => {
+                            const next = { ...prev };
+                            delete next[modelId];
+                            return next;
+                        });
+                    } else {
+                        setDownloading(prev => ({ ...prev, [modelId]: task.progress }));
+                    }
+                }
+            }
+        });
+        return unsubscribe;
+    }, []);
+
     const handleDownload = async (model: PresetModel) => {
         onModelSelect?.(model);
         setDownloading(prev => ({ ...prev, [model.id]: 0 }));
         try {
-            await getMessage().post(
-                'api/preset_download',
-                { name: model.name, source: model.source, base: model.base || '' },
-                {
-                    download_progress: (data: any) => {
-                        const progress = Math.round(data?.progress ?? 0);
-                        setDownloading(prev => ({ ...prev, [model.id]: progress }));
-                    }
-                }
+            const isUrl = model.source.startsWith('http://') || model.source.startsWith('https://');
+            const taskId = await taskService.current.createDownloadTask(
+                'preset',
+                model.name,
+                isUrl ? model.source : undefined,
+                isUrl ? undefined : model.source
             );
+            taskIds.current[model.id] = taskId;
         } catch (error) {
             console.error('预设模型下载失败:', error);
-        } finally {
-            setDownloading(prev => {
-                const next = { ...prev };
-                delete next[model.id];
-                return next;
-            });
         }
     };
 

--- a/desktop/src/services/TaskService.ts
+++ b/desktop/src/services/TaskService.ts
@@ -64,6 +64,33 @@ class TaskService {
         });
     }
 
+    /**
+     * 通过统一任务队列创建下载任务（HTTP 直链或 HuggingFace 仓库）。
+     * @returns 任务 id；失败抛异常。
+     */
+    public async createDownloadTask(
+        kind: string,
+        name: string,
+        url?: string,
+        repo_id?: string
+    ): Promise<string> {
+        const response = await fetch(`${this.getBaseUrl()}/api/tasks/download`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ kind, name, url, repo_id })
+        });
+        if (!response.ok) {
+            throw new Error(`Failed to create download task: ${response.status}`);
+        }
+        const data = await response.json();
+        if (!data.task_id) {
+            throw new Error('Failed to create download task: missing task_id');
+        }
+        return data.task_id as string;
+    }
+
     public subscribe(callback: (task: QueueTask) => void): () => void {
         this.listeners.push(callback);
         this.ensureSocket();


### PR DESCRIPTION
补上 0.2 的最后一层接线：Preset/HuggingFace 模型下载改为通过 POST /api/tasks/download 创建任务，进度由 websocket task_update 推送，下载任务会同步显示在任务队列页。desktop build 已通过。