### PR TITLE
fix(model): 模型安装页 API 调用改为绝对地址

### DIFF
--- a/desktop/src/components/ModelAdding/CivitaiModels/index.tsx
+++ b/desktop/src/components/ModelAdding/CivitaiModels/index.tsx
@@ -5,6 +5,7 @@ import { CivitaiModel } from '../../../types/civitai';
 import styles from './style.module.css';
 import { TauriDownloaderProvider } from '../../../providers/TauriDownloaderProvider';
 import { DownloadTask } from '../../../providers/IDownloaderProvider';
+import { getApiBaseUrl } from '../../../services/apiBase';
 
 interface CivitaiModelsProps {
     onModelSelect?: (model: CivitaiModel) => void;
@@ -32,7 +33,7 @@ export const CivitaiModels: React.FC<CivitaiModelsProps> = () => {
     const fetchModels = async (query?: string) => {
         try {
             setLoading(true);
-            const response = await axios.get('/api/civitai/models', {
+            const response = await axios.get(`${getApiBaseUrl()}/api/civitai/models`, {
                 params: {
                     query: query || undefined,
                     page: 1,

--- a/desktop/src/components/ModelAdding/HuggingfaceModels/index.tsx
+++ b/desktop/src/components/ModelAdding/HuggingfaceModels/index.tsx
@@ -5,6 +5,7 @@ import HuggingfaceLogo from './logo_huggingface.svg'
 import ModelLogo from './logo_model.svg'
 import styles from './style.module.css'
 import TaskService from '../../../services/TaskService';
+import { getApiBaseUrl } from '../../../services/apiBase';
 
 export interface HuggingfaceModel {
     id: string;
@@ -70,7 +71,7 @@ const HuggingfaceModels: React.FC<HuggingfaceModelsProps> = () => {
             setError(null);
             setHasSearched(true);
 
-            const response = await axios.get('/api/hf/models', {
+            const response = await axios.get(`${getApiBaseUrl()}/api/hf/models`, {
                 params: {
                     search: inputValue,
                     limit: 50,
@@ -95,7 +96,7 @@ const HuggingfaceModels: React.FC<HuggingfaceModelsProps> = () => {
             setHasSearched(true);
 
             // 获取单个仓库信息
-            const response = await axios.get(`/api/hf/models/${encodeURIComponent(inputValue)}`);
+            const response = await axios.get(`${getApiBaseUrl()}/api/hf/models/${encodeURIComponent(inputValue)}`);
 
             // 如果成功获取，添加到模型列表的开头
             if (response.data) {

--- a/desktop/src/components/ModelAdding/PresetModels/index.tsx
+++ b/desktop/src/components/ModelAdding/PresetModels/index.tsx
@@ -3,6 +3,7 @@ import { Button, Icon, Tooltip, ProgressBar } from '@blueprintjs/core';
 import styles from './style.module.css';
 import { useTranslation } from 'react-i18next';
 import TaskService from '../../../services/TaskService';
+import { getApiBaseUrl } from '../../../services/apiBase';
 
 interface PresetModel {
     id: string;
@@ -49,7 +50,7 @@ export const PresetModels: React.FC<PresetModelsProps> = ({ onModelSelect }) => 
         const fetchPresets = async () => {
             try {
                 setLoading(true);
-                const response = await fetch('/api/preset_models');
+                const response = await fetch(`${getApiBaseUrl()}/api/preset_models`);
                 if (!response.ok) {
                     throw new Error(`Failed to fetch preset models: ${response.status}`);
                 }

--- a/desktop/src/services/apiBase.ts
+++ b/desktop/src/services/apiBase.ts
@@ -1,0 +1,15 @@
+import GlobalStateManager from './GlobalState';
+
+/**
+ * 获取 FastAPI 后端的 HTTP 基础地址。
+ *
+ * 桌面壳由 Tauri 承载（开发时 localhost:1420，打包后 tauri.localhost），
+ * 与后端（7422，或开发时经 functional_ui 7420 代理）不同源，
+ * 因此所有 /api 调用必须使用绝对地址。
+ */
+export function getApiBaseUrl(): string {
+    const rootState = GlobalStateManager.getInstance().getRootState();
+    const host = rootState?.host || 'localhost';
+    const port = rootState?.port || 7422;
+    return `http://${host}:${port}`;
+}


### PR DESCRIPTION
修复 Civitai/HuggingFace/预设模型页失效：桌面壳（Tauri）与 FastAPI 后端不同源，相对路径 /api/* 到不了 7422。新增 getApiBaseUrl()（基于 GlobalState）并替换三处调用。desktop build 已通过。