### PR TITLE
fix(queue): 生图任务可删除/清除，避免历史任务常驻队列

### DIFF
--- a/server/routes/task_routes.py
+++ b/server/routes/task_routes.py
@@ -21,13 +21,23 @@ def _scheduler_task_to_dict(task) -> Dict[str, Any]:
     }
     status = getattr(task, "status", None)
     status_value = status.value if hasattr(status, "value") else str(status or "pending")
+
+    def to_timestamp(value) -> float:
+        if not value:
+            return 0.0
+        try:
+            from datetime import datetime
+            return datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+        except Exception:
+            return 0.0
+
     return {
         "id": task.task_id,
         "kind": "generation",
         "name": f"{task.callable} · {os.path.basename(task.script)}",
         "status": status_map.get(status_value, status_value),
         "progress": 100 if status_value == "completed" else 0,
-        "createdAt": time.time(),
+        "createdAt": to_timestamp(task.started_at) or to_timestamp(task.completed_at) or time.time(),
         "error": task.error,
         "meta": {"script": task.script, "callable": task.callable},
     }
@@ -176,16 +186,28 @@ async def create_download_task(
 
 @router.delete("/api/tasks/{task_id}")
 async def remove_task(request: Request, task_id: str):
+    """移除任务：优先移除下载任务，其次移除调度器中已结束的生图任务。"""
     task_service = request.app.state.task_service
+    scheduler = request.app.state.scheduler
     removed = task_service.remove(task_id)
+    if not removed:
+        remove_method = getattr(scheduler, "remove_task", None)
+        if remove_method is not None:
+            removed = remove_method(task_id)
     return {"success": removed}
 
 
 @router.post("/api/tasks/clear")
 async def clear_completed_tasks(request: Request):
+    """清除所有已结束任务（下载任务 + 生图任务）。"""
     task_service = request.app.state.task_service
+    scheduler = request.app.state.scheduler
     count = task_service.clear_completed()
-    return {"success": True, "removed": count}
+    scheduler_removed = 0
+    clear_method = getattr(scheduler, "clear_completed_tasks", None)
+    if clear_method is not None:
+        scheduler_removed = clear_method()
+    return {"success": True, "removed": count, "scheduler_removed": scheduler_removed}
 
 
 @router.post("/api/tasks/{task_id}/cancel")

--- a/ss_executor/scheduler.py
+++ b/ss_executor/scheduler.py
@@ -158,6 +158,34 @@ class TaskScheduler:
         """获取所有任务"""
         return list(self.tasks.values())
 
+    def remove_task(self, task_id: str) -> bool:
+        """移除一个已结束的任务（completed/failed/cancelled）。"""
+        task = self.tasks.get(task_id)
+        if task is None:
+            return False
+        if task.status not in [
+            TaskStatus.COMPLETED,
+            TaskStatus.FAILED,
+            TaskStatus.CANCELLED,
+        ]:
+            return False
+        del self.tasks[task_id]
+        self.task_completion_events.pop(task_id, None)
+        return True
+
+    def clear_completed_tasks(self) -> int:
+        """清除所有已结束的任务，返回清除数量。"""
+        terminal_ids = [
+            task_id
+            for task_id, task in self.tasks.items()
+            if task.status
+            in [TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.CANCELLED]
+        ]
+        for task_id in terminal_ids:
+            del self.tasks[task_id]
+            self.task_completion_events.pop(task_id, None)
+        return len(terminal_ids)
+
     def get_all_executors(self) -> List[ExecutorInfo]:
         """获取所有执行器信息"""
         return list(self.executors.values())


### PR DESCRIPTION
修复任务队列里一直残留几个任务：调度器 self.tasks 只增不减，GET /api/tasks 会把所有历史生图任务一直列出，且删除/清除只作用于下载任务。新增 TaskScheduler.remove_task/clear_completed_tasks 并接入 DELETE /api/tasks/{id} 与 POST /api/tasks/clear；生图任务 createdAt 改为稳定时间戳。TestClient 已验证删除与清除生效。