### PR TITLE
feat(workflow): 实现函数定义与函数调用流程系统

### DIFF
--- a/frontend/ssui_components/src/shared/Nodes.tsx
+++ b/frontend/ssui_components/src/shared/Nodes.tsx
@@ -1,12 +1,13 @@
+import type { ReactNode } from 'react';
 import { Button } from '@blueprintjs/core';
-import { ClassicPreset, GetSchemes } from 'rete';
-import { ReactArea2D,  } from 'rete-react-plugin';
+import { ClassicPreset, GetSchemes, NodeEditor } from 'rete';
+import { Presets as ReactPresets, ReactArea2D, type RenderEmit } from 'rete-react-plugin';
 import {
     ContextMenuExtra,
 } from "rete-context-menu-plugin";
 import { AreaPlugin } from 'rete-area-plugin';
 
-class Connection<
+export class Connection<
     A extends BaseNode,
     B extends BaseNode
 > extends ClassicPreset.Connection<A, B> { }
@@ -18,7 +19,6 @@ export type Schemes = GetSchemes<
 
 export type AreaExtra = ReactArea2D<any> | ContextMenuExtra;
 
-
 export class BaseNode extends ClassicPreset.Node<
     { [key in string]: ClassicPreset.Socket },
     { [key in string]: ClassicPreset.Socket },
@@ -26,62 +26,102 @@ export class BaseNode extends ClassicPreset.Node<
         ClassicPreset.Control
         | ButtonControl
         | ParameterControl
+        | NameControl
+        | InfoControl
         | ClassicPreset.InputControl<"number">
         | ClassicPreset.InputControl<"text">
     }
-> { }
+> {
+    protected area?: AreaPlugin<Schemes, AreaExtra>;
+    protected refreshOverride?: () => void;
 
-// Input节点组件
-export class InputNode extends BaseNode {
-    private parameters: ParameterControl[] = [];
-    private socketCounter = 0;
-
-    constructor(private area: AreaPlugin<Schemes, AreaExtra>) {
-        super('Input');
-        this.addOutput('default', new ClassicPreset.Output(new ClassicPreset.Socket('默认输出')));
-        this.addControl('button', new ButtonControl('添加参数', () => {
-            console.log('按钮被点击');
-            const parameter = new ParameterControl('新参数', 'string');
-            this.addControl(`parameter${this.parameters.length}`, parameter);
-            this.parameters.push(parameter);
-            this.area.update('node', this.id);
-        }));
+    getEditor(): NodeEditor<Schemes> | undefined {
+        if (!this.area) return undefined;
+        try {
+            return this.area.parentScope(NodeEditor) as NodeEditor<Schemes>;
+        } catch {
+            return undefined;
+        }
     }
 
-    addOutputSocket() {
-        const socketId = `output_${this.socketCounter++}`;
-        this.addOutput(socketId, new ClassicPreset.Output(new ClassicPreset.Socket('新输出')));
-        this.parameters.push(new ParameterControl('新参数', 'string'));
-        return socketId;
+    protected refresh(): void {
+        if (this.refreshOverride) {
+            this.refreshOverride();
+        } else if (this.area) {
+            void this.area.update('node', this.id);
+        }
     }
 
-    getParameters() {
-        return this.parameters;
+    protected removeConnectionsForPort(key: string, side: 'input' | 'output'): void {
+        const editor = this.getEditor();
+        if (!editor) return;
+        const doomed = editor.getConnections().filter((c) => {
+            if (side === 'output') {
+                return c.source === this.id && c.sourceOutput === key;
+            }
+            return c.target === this.id && c.targetInput === key;
+        });
+        doomed.forEach((c) => void editor.removeConnection(c.id));
+    }
+
+    // 根据“输入参数/返回值”两组规格，同步外层输入/输出端口
+    protected syncPortsFromInner(inputSpecs: ParamSpec[], outputSpecs: ParamSpec[]): void {
+        const desiredInputs = new Set(inputSpecs.map((p) => `in_${p.key}`));
+        const desiredOutputs = new Set(outputSpecs.map((r) => `out_${r.key}`));
+
+        const editor = this.getEditor();
+        if (editor) {
+            editor.getConnections()
+                .filter((c) => {
+                    const touchesRemovedInput =
+                        c.target === this.id &&
+                        c.targetInput in this.inputs &&
+                        !desiredInputs.has(c.targetInput as string);
+                    const touchesRemovedOutput =
+                        c.source === this.id &&
+                        c.sourceOutput in this.outputs &&
+                        !desiredOutputs.has(c.sourceOutput as string);
+                    return touchesRemovedInput || touchesRemovedOutput;
+                })
+                .forEach((c) => void editor.removeConnection(c.id));
+        }
+
+        Object.keys(this.inputs).forEach((key) => {
+            if (!desiredInputs.has(key)) this.removeInput(key);
+        });
+        Object.keys(this.outputs).forEach((key) => {
+            if (!desiredOutputs.has(key)) this.removeOutput(key);
+        });
+
+        inputSpecs.forEach((p) => {
+            const key = `in_${p.key}`;
+            if (this.hasInput(key)) {
+                this.inputs[key]!.label = p.name;
+                this.inputs[key]!.socket = new ClassicPreset.Socket(p.name);
+            } else {
+                this.addInput(key, new ClassicPreset.Input(new ClassicPreset.Socket(p.name), p.name));
+            }
+        });
+
+        outputSpecs.forEach((r) => {
+            const key = `out_${r.key}`;
+            if (this.hasOutput(key)) {
+                this.outputs[key]!.label = r.name;
+                this.outputs[key]!.socket = new ClassicPreset.Socket(r.name);
+            } else {
+                this.addOutput(key, new ClassicPreset.Output(new ClassicPreset.Socket(r.name), r.name));
+            }
+        });
     }
 }
 
-// Output节点组件
-export class OutputNode extends BaseNode {
-    private returnTypes: string[] = [];
-    private socketCounter = 0;
-
-    constructor(private area: AreaPlugin<Schemes, AreaExtra>) {
-        super('Output');
-        this.addInput('default', new ClassicPreset.Input(new ClassicPreset.Socket('默认输入')));
-    }
-
-    addInputSocket() {
-        const socketId = `input_${this.socketCounter++}`;
-        this.addInput(socketId, new ClassicPreset.Input(new ClassicPreset.Socket('新输入')));
-        this.returnTypes.push('string');
-        return socketId;
-    }
-
-    getReturnTypes() {
-        return this.returnTypes;
-    }
+export interface ParamSpec {
+    key: string;
+    name: string;
+    type: string;
 }
 
+// ============ 控件 ============
 
 export class ButtonControl extends ClassicPreset.Control {
     constructor(public label: string, public onClick: () => void) {
@@ -94,6 +134,8 @@ export class ButtonControl extends ClassicPreset.Control {
 export function ButtonControlRender(props: { data: ButtonControl }) {
     return (
         <Button
+            small={true}
+            minimal={true}
             onPointerDown={(e) => e.stopPropagation()}
             onDoubleClick={(e) => e.stopPropagation()}
             onClick={props.data.onClick}
@@ -103,19 +145,497 @@ export function ButtonControlRender(props: { data: ButtonControl }) {
     );
 }
 
-export class ParameterControl extends ClassicPreset.Control {
-    constructor(public label: string, public type: string) {
+export class NameControl extends ClassicPreset.Control {
+    constructor(public value: string, public onChange: (value: string) => void) {
         super();
-        this.label = label;
-        this.type = type;
+        this.value = value;
+        this.onChange = onChange;
+    }
+}
+
+export function NameControlRender(props: { data: NameControl }) {
+    return (
+        <input
+            className="flow-name-input"
+            type="text"
+            value={props.data.value}
+            placeholder="名称"
+            onPointerDown={(e) => e.stopPropagation()}
+            onDoubleClick={(e) => e.stopPropagation()}
+            onChange={(e) => props.data.onChange(e.target.value)}
+        />
+    );
+}
+
+export class ParameterControl extends ClassicPreset.Control {
+    constructor(
+        public spec: ParamSpec,
+        public onNameChange: (value: string) => void,
+        public onTypeChange: (value: string) => void,
+        public onRemove: () => void
+    ) {
+        super();
+        this.spec = spec;
+        this.onNameChange = onNameChange;
+        this.onTypeChange = onTypeChange;
+        this.onRemove = onRemove;
     }
 }
 
 export function ParameterControlRender(props: { data: ParameterControl }) {
+    const control = props.data;
     return (
-        <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', justifyContent: 'center' }}>
-            <input style={{ flex: 1 , width: '50px' }} type="text" value={props.data.label} />
-            <input style={{ flex: 1 , width: '50px' }} type="text" value={props.data.type} />
+        <div
+            className="flow-param-row"
+            onPointerDown={(e) => e.stopPropagation()}
+            onDoubleClick={(e) => e.stopPropagation()}
+        >
+            <input
+                className="flow-param-name"
+                type="text"
+                value={control.spec.name}
+                placeholder="参数名"
+                onChange={(e) => control.onNameChange(e.target.value)}
+            />
+            <input
+                className="flow-param-type"
+                type="text"
+                value={control.spec.type}
+                placeholder="类型"
+                onChange={(e) => control.onTypeChange(e.target.value)}
+            />
+            <Button
+                small={true}
+                minimal={true}
+                icon="cross"
+                title="删除"
+                onPointerDown={(e) => e.stopPropagation()}
+                onClick={control.onRemove}
+            />
+        </div>
+    );
+}
+
+export class InfoControl extends ClassicPreset.Control {
+    constructor(public text: string) {
+        super();
+        this.text = text;
+    }
+}
+
+export function InfoControlRender(props: { data: InfoControl }) {
+    return (
+        <div
+            className="flow-info-text"
+            onPointerDown={(e) => e.stopPropagation()}
+            onDoubleClick={(e) => e.stopPropagation()}
+        >
+            {props.data.text}
+        </div>
+    );
+}
+
+// ============ 输入节点（流程参数） ============
+
+export class InputNode extends BaseNode {
+    private parameters: ParamSpec[] = [];
+    private counter = 0;
+
+    constructor(
+        area?: AreaPlugin<Schemes, AreaExtra>,
+        refreshOverride?: () => void
+    ) {
+        super('输入');
+        this.area = area;
+        this.refreshOverride = refreshOverride;
+        this.addControl('add', new ButtonControl('添加参数', () => this.addParameter()));
+    }
+
+    addParameter(): ParamSpec {
+        const key = `param_${this.counter++}`;
+        const spec: ParamSpec = {
+            key,
+            name: `参数 ${this.parameters.length + 1}`,
+            type: 'string',
+        };
+        this.parameters.push(spec);
+        this.addOutput(key, new ClassicPreset.Output(new ClassicPreset.Socket(spec.name), spec.name));
+        this.addControl(
+            key,
+            new ParameterControl(
+                spec,
+                (name) => {
+                    spec.name = name;
+                    this.syncOutput(key);
+                    this.refresh();
+                },
+                (type) => {
+                    spec.type = type;
+                    this.refresh();
+                },
+                () => this.removeParameter(key)
+            )
+        );
+        this.refresh();
+        return spec;
+    }
+
+    removeParameter(key: string): void {
+        const index = this.parameters.findIndex((p) => p.key === key);
+        if (index < 0) return;
+        this.parameters.splice(index, 1);
+        this.removeConnectionsForPort(key, 'output');
+        this.removeOutput(key);
+        this.removeControl(key);
+        this.refresh();
+    }
+
+    private syncOutput(key: string): void {
+        const spec = this.parameters.find((p) => p.key === key);
+        const output = this.outputs[key];
+        if (spec && output) {
+            output.label = spec.name;
+            output.socket = new ClassicPreset.Socket(spec.name);
+        }
+    }
+
+    getParameters(): ParamSpec[] {
+        return this.parameters;
+    }
+}
+
+// ============ 返回节点（返回值） ============
+
+export class OutputNode extends BaseNode {
+    private returns: ParamSpec[] = [];
+    private counter = 0;
+
+    constructor(
+        area?: AreaPlugin<Schemes, AreaExtra>,
+        refreshOverride?: () => void
+    ) {
+        super('返回');
+        this.area = area;
+        this.refreshOverride = refreshOverride;
+        this.addControl('add', new ButtonControl('添加返回值', () => this.addReturn()));
+    }
+
+    addReturn(): ParamSpec {
+        const key = `return_${this.counter++}`;
+        const spec: ParamSpec = {
+            key,
+            name: `返回值 ${this.returns.length + 1}`,
+            type: 'string',
+        };
+        this.returns.push(spec);
+        this.addInput(key, new ClassicPreset.Input(new ClassicPreset.Socket(spec.name), spec.name));
+        this.addControl(
+            key,
+            new ParameterControl(
+                spec,
+                (name) => {
+                    spec.name = name;
+                    this.syncInput(key);
+                    this.refresh();
+                },
+                (type) => {
+                    spec.type = type;
+                    this.refresh();
+                },
+                () => this.removeReturn(key)
+            )
+        );
+        this.refresh();
+        return spec;
+    }
+
+    removeReturn(key: string): void {
+        const index = this.returns.findIndex((r) => r.key === key);
+        if (index < 0) return;
+        this.returns.splice(index, 1);
+        this.removeConnectionsForPort(key, 'input');
+        this.removeInput(key);
+        this.removeControl(key);
+        this.refresh();
+    }
+
+    private syncInput(key: string): void {
+        const spec = this.returns.find((r) => r.key === key);
+        const input = this.inputs[key];
+        if (spec && input) {
+            input.label = spec.name;
+            input.socket = new ClassicPreset.Socket(spec.name);
+        }
+    }
+
+    getReturns(): ParamSpec[] {
+        return this.returns;
+    }
+
+    getReturnTypes(): string[] {
+        return this.returns.map((r) => r.type);
+    }
+}
+
+// ============ 算子（函数内部子元素示例） ============
+
+export class OperatorNode extends BaseNode {
+    constructor(name: string, refresh?: () => void) {
+        super(name);
+        this.addInput('input', new ClassicPreset.Input(new ClassicPreset.Socket('输入'), '输入'));
+        this.addOutput('output', new ClassicPreset.Output(new ClassicPreset.Socket('输出'), '输出'));
+        const nameControl = new NameControl(name, () => {});
+        this.addControl(
+            'name',
+            nameControl
+        );
+        nameControl.onChange = (value) => {
+            this.label = value;
+            nameControl.value = value;
+            refresh?.();
+        };
+    }
+}
+
+// ============ 函数定义节点（一个大方框 = 一个 Python 函数） ============
+
+export class FunctionDefinitionNode extends BaseNode {
+    static counter = 0;
+    children: BaseNode[] = [];
+    private callers: FunctionCallNode[] = [];
+
+    constructor(
+        area: AreaPlugin<Schemes, AreaExtra>,
+        name?: string
+    ) {
+        const fnName = name ?? `函数 ${++FunctionDefinitionNode.counter}`;
+        super(fnName);
+        this.area = area;
+
+        // 内部的输入/返回节点：它们的参数/返回值就是这个函数的输入/输出
+        const refresh = () => {
+            this.syncSignature();
+            this.refresh();
+        };
+        const innerInput = new InputNode(undefined, refresh);
+        const innerOutput = new OutputNode(undefined, refresh);
+        this.children.push(innerInput, innerOutput);
+
+        const nameControl = new NameControl(fnName, () => {});
+        this.addControl('name', nameControl);
+        nameControl.onChange = (value) => {
+            this.label = value;
+            nameControl.value = value;
+            this.syncCallers();
+            this.refresh();
+        };
+        this.addControl('addChild', new ButtonControl('添加子节点', () => this.addChild()));
+        this.addControl('createCall', new ButtonControl('创建函数调用', () => this.createCall()));
+
+        // 默认一个参数、一个返回值
+        innerInput.addParameter();
+        innerOutput.addReturn();
+        this.syncSignature();
+    }
+
+    getInnerInput(): InputNode {
+        return this.children.find((c): c is InputNode => c instanceof InputNode)!;
+    }
+
+    getInnerOutput(): OutputNode {
+        return this.children.find((c): c is OutputNode => c instanceof OutputNode)!;
+    }
+
+    addParameter(): ParamSpec {
+        return this.getInnerInput().addParameter();
+    }
+
+    removeParameter(key: string): void {
+        this.getInnerInput().removeParameter(key);
+    }
+
+    addReturn(): ParamSpec {
+        return this.getInnerOutput().addReturn();
+    }
+
+    removeReturn(key: string): void {
+        this.getInnerOutput().removeReturn(key);
+    }
+
+    addChild(): BaseNode {
+        const child = new OperatorNode(`算子 ${this.children.length - 1}`, () => this.refresh());
+        this.children.push(child);
+        this.refresh();
+        return child;
+    }
+
+    registerCaller(caller: FunctionCallNode): void {
+        if (!this.callers.includes(caller)) {
+            this.callers.push(caller);
+        }
+    }
+
+    unregisterCaller(caller: FunctionCallNode): void {
+        this.callers = this.callers.filter((c) => c !== caller);
+    }
+
+    // 根据定义创建/更新调用节点，并放到定义右侧
+    async createCall(): Promise<FunctionCallNode> {
+        const caller = new FunctionCallNode(this.area!, this);
+        await this.area!.parentScope(NodeEditor).addNode(caller);
+        const pos = this.area!.nodeViews.get(this.id)?.position;
+        await this.area!.translate(caller.id, {
+            x: (pos?.x ?? 0) + 300,
+            y: pos?.y ?? 0,
+        });
+        return caller;
+    }
+
+    // 把内部输入节点的参数同步为外层输入端口，内部返回节点同步为外层输出端口
+    private syncSignature(): void {
+        this.syncPortsFromInner(
+            this.getInnerInput().getParameters(),
+            this.getInnerOutput().getReturns()
+        );
+        this.syncCallers();
+    }
+
+    // 函数签名/名称变化后，同步所有引用它的调用节点
+    private syncCallers(): void {
+        this.callers.forEach((caller) => {
+            caller.syncSignature();
+            if (caller.getEditor()?.getNode(caller.id)) {
+                void this.area?.update('node', caller.id);
+            }
+        });
+    }
+}
+
+// ============ 函数调用节点（端口数量由被调用的函数定义决定） ============
+
+export class FunctionCallNode extends BaseNode {
+    constructor(
+        area: AreaPlugin<Schemes, AreaExtra>,
+        public definition: FunctionDefinitionNode
+    ) {
+        super(definition.label);
+        this.area = area;
+        this.definition = definition;
+        this.addControl('info', new InfoControl('函数调用'));
+        definition.registerCaller(this);
+        this.syncSignature();
+    }
+
+    // 从函数定义同步名称和端口：输入端口 = 定义的参数，输出端口 = 定义的返回值
+    syncSignature(): void {
+        this.label = this.definition.label;
+        this.syncPortsFromInner(
+            this.definition.getInnerInput().getParameters(),
+            this.definition.getInnerOutput().getReturns()
+        );
+    }
+}
+
+// ============ 函数定义节点的自定义渲染（大矩形框） ============
+
+function renderControl(control: ClassicPreset.Control): ReactNode | null {
+    if (control instanceof ButtonControl) {
+        return <ButtonControlRender data={control} />;
+    }
+    if (control instanceof ParameterControl) {
+        return <ParameterControlRender data={control} />;
+    }
+    if (control instanceof NameControl) {
+        return <NameControlRender data={control} />;
+    }
+    if (control instanceof InfoControl) {
+        return <InfoControlRender data={control} />;
+    }
+    return null;
+}
+
+function ChildBlock({ child }: { child: BaseNode }) {
+    const entries = Object.entries(child.controls).filter(([, control]) => control);
+    const addEntry = entries.find(([key]) => key === 'add');
+    const rest = entries.filter(([key]) => key !== 'add');
+    const ordered = addEntry ? [...rest, addEntry] : rest;
+
+    return (
+        <div className="flow-child-node">
+            <div className="flow-child-title">{child.label}</div>
+            {ordered.map(([, control]) => (
+                <div className="flow-child-control" key={control!.id}>
+                    {renderControl(control!)}
+                </div>
+            ))}
+        </div>
+    );
+}
+
+export function FunctionDefinitionRender(props: {
+    data: BaseNode;
+    emit: RenderEmit<Schemes>;
+}): React.JSX.Element {
+    const node = props.data as FunctionDefinitionNode;
+    const inputs = Object.entries(node.inputs).filter(([, input]) => input);
+    const outputs = Object.entries(node.outputs).filter(([, output]) => output);
+    const nameControl = node.controls['name'];
+    const addChildControl = node.controls['addChild'];
+    const createCallControl = node.controls['createCall'];
+
+    return (
+        <div className={`flow-function-node${node.selected ? ' selected' : ''}`}>
+            <div className="flow-function-header">
+                <span className="flow-function-badge">函数定义</span>
+                {nameControl instanceof NameControl && <NameControlRender data={nameControl} />}
+                <span className="flow-function-meta">
+                    {inputs.length} 参数 · {outputs.length} 返回值
+                </span>
+            </div>
+
+            <div className="flow-function-children">
+                {node.children.map((child) => (
+                    <ChildBlock key={child.id} child={child} />
+                ))}
+            </div>
+
+            <div className="flow-function-footer">
+                {addChildControl instanceof ButtonControl && <ButtonControlRender data={addChildControl} />}
+                {createCallControl instanceof ButtonControl && <ButtonControlRender data={createCallControl} />}
+            </div>
+
+            <div className="flow-function-ports">
+                <div className="flow-function-inputs">
+                    {inputs.map(([key, input]) => (
+                        <div className="flow-port-row" key={key}>
+                            <ReactPresets.classic.RefSocket
+                                name="input-socket"
+                                side="input"
+                                socketKey={key}
+                                nodeId={node.id}
+                                emit={props.emit}
+                                payload={input!.socket}
+                            />
+                            <span className="flow-port-label">{input!.label}</span>
+                        </div>
+                    ))}
+                </div>
+                <div className="flow-function-outputs">
+                    {outputs.map(([key, output]) => (
+                        <div className="flow-port-row" key={key}>
+                            <span className="flow-port-label">{output!.label}</span>
+                            <ReactPresets.classic.RefSocket
+                                name="output-socket"
+                                side="output"
+                                socketKey={key}
+                                nodeId={node.id}
+                                emit={props.emit}
+                                payload={output!.socket}
+                            />
+                        </div>
+                    ))}
+                </div>
+            </div>
         </div>
     );
 }

--- a/frontend/ssui_components/src/shared/Workflow.css
+++ b/frontend/ssui_components/src/shared/Workflow.css
@@ -1,0 +1,216 @@
+/* ============ 工作流画布与工具栏 ============ */
+
+.workflow-ui {
+    position: relative;
+    width: 100%;
+    height: 100vh;
+}
+
+.workflow-toolbar {
+    position: absolute;
+    top: 12px;
+    left: 12px;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    background: rgba(28, 31, 48, 0.92);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
+    pointer-events: auto;
+}
+
+.workflow-toolbar-button {
+    border: none;
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 13px;
+    color: #e6e9ff;
+    background: #4e58bf;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.workflow-toolbar-button:hover {
+    background: #5f69d6;
+}
+
+.workflow-toolbar-clear {
+    background: #7a3f4d;
+}
+
+.workflow-toolbar-clear:hover {
+    background: #93505f;
+}
+
+/* ============ 函数调用节点（大矩形框） ============ */
+
+.flow-function-node {
+    width: 380px;
+    box-sizing: border-box;
+    background: #23273f;
+    border: 2px solid #4e58bf;
+    border-radius: 12px;
+    color: #fff;
+    font-family: Arial, sans-serif;
+    user-select: none;
+    line-height: initial;
+    padding: 8px 12px 12px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+}
+
+.flow-function-node.selected {
+    background: #343a5e;
+    border-color: #ffd92c;
+}
+
+.flow-function-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.flow-function-badge {
+    flex-shrink: 0;
+    padding: 2px 10px;
+    border-radius: 999px;
+    background: #4e58bf;
+    font-size: 12px;
+    font-weight: bold;
+    white-space: nowrap;
+}
+
+.flow-name-input {
+    flex: 1;
+    min-width: 60px;
+    padding: 4px 8px;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    font-size: 14px;
+    box-sizing: border-box;
+}
+
+.flow-name-input:focus {
+    outline: none;
+    border-color: #8f97ea;
+    background: rgba(255, 255, 255, 0.2);
+}
+
+.flow-function-meta {
+    flex-shrink: 0;
+    font-size: 12px;
+    color: #aeb4d8;
+    white-space: nowrap;
+}
+
+.flow-function-children {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    padding: 10px 0;
+}
+
+.flow-child-node {
+    flex: 1;
+    min-width: 140px;
+    box-sizing: border-box;
+    background: #2c3150;
+    border: 1px solid #4e58bf;
+    border-radius: 8px;
+    padding: 6px 8px;
+}
+
+.flow-child-title {
+    font-size: 13px;
+    font-weight: bold;
+    color: #dfe3ff;
+    padding-bottom: 4px;
+    margin-bottom: 4px;
+    border-bottom: 1px dashed rgba(255, 255, 255, 0.2);
+}
+
+.flow-child-control {
+    margin: 3px 0;
+}
+
+.flow-param-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.flow-param-row input {
+    width: 56px;
+    box-sizing: border-box;
+    padding: 3px 6px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 5px;
+    background: rgba(255, 255, 255, 0.1);
+    color: #fff;
+    font-size: 12px;
+}
+
+.flow-param-row input:focus {
+    outline: none;
+    border-color: #8f97ea;
+}
+
+.flow-function-footer {
+    display: flex;
+    gap: 6px;
+    padding-top: 6px;
+    border-top: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.flow-function-ports {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-top: 6px;
+}
+
+.flow-function-inputs,
+.flow-function-outputs {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.flow-port-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 13px;
+    color: #dfe3ff;
+}
+
+.flow-function-inputs .flow-port-row {
+    margin-left: -10px;
+}
+
+.flow-function-outputs .flow-port-row {
+    justify-content: flex-end;
+    margin-right: -10px;
+}
+
+.flow-port-label {
+    max-width: 110px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.flow-info-text {
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: rgba(78, 88, 191, 0.35);
+    color: #cfd5ff;
+    font-size: 12px;
+    text-align: center;
+}

--- a/frontend/ssui_components/src/shared/Workflow.tsx
+++ b/frontend/ssui_components/src/shared/Workflow.tsx
@@ -2,13 +2,33 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { NodeEditor, ClassicPreset } from 'rete';
 import { AreaPlugin, AreaExtensions } from 'rete-area-plugin';
-import { ReactPlugin, Presets as ReactPresets, useRete, RenderEmit, Presets } from 'rete-react-plugin';
+import { ReactPlugin, Presets as ReactPresets, useRete } from 'rete-react-plugin';
 import {
     ConnectionPlugin,
     Presets as ConnectionPresets,
 } from "rete-connection-plugin";
+import { ContextMenuPlugin } from "rete-context-menu-plugin";
 
-import { AreaExtra, ButtonControl, ButtonControlRender, InputNode, OutputNode, ParameterControl, ParameterControlRender, Schemes } from './Nodes';
+import {
+    AreaExtra,
+    BaseNode,
+    ButtonControl,
+    ButtonControlRender,
+    Connection,
+    FunctionCallNode,
+    FunctionDefinitionNode,
+    FunctionDefinitionRender,
+    InputNode,
+    NameControl,
+    NameControlRender,
+    OutputNode,
+    ParameterControl,
+    ParameterControlRender,
+    InfoControl,
+    InfoControlRender,
+    Schemes,
+} from './Nodes';
+import './Workflow.css';
 
 export interface WorkflowProps {
     path: string;
@@ -22,16 +42,85 @@ const createEditor = async (container: HTMLElement) => {
     const connection = new ConnectionPlugin<Schemes, AreaExtra>();
     const reactRender = new ReactPlugin<Schemes, AreaExtra>({ createRoot });
 
+    const addNode = async (node: BaseNode) => {
+        await editor.addNode(node);
+        await area.translate(node.id, area.area.pointer);
+    };
+
+    const contextMenu = new ContextMenuPlugin<Schemes>({
+        items: (context) => {
+            if (context === 'root') {
+                const definitions = editor.getNodes().filter(
+                    (n): n is FunctionDefinitionNode => n instanceof FunctionDefinitionNode
+                );
+                return {
+                    searchBar: true,
+                    list: [
+                        { label: '输入节点', key: 'input', handler: () => addNode(new InputNode(area)) },
+                        { label: '返回节点', key: 'output', handler: () => addNode(new OutputNode(area)) },
+                        { label: '函数定义', key: 'definition', handler: () => addNode(new FunctionDefinitionNode(area)) },
+                        {
+                            label: '函数调用',
+                            key: 'call',
+                            handler: async () => {
+                                // 无子菜单时的兜底：直接调用第一个函数定义
+                                const def = editor.getNodes().find(
+                                    (n): n is FunctionDefinitionNode => n instanceof FunctionDefinitionNode
+                                );
+                                if (def) await addNode(new FunctionCallNode(area, def));
+                            },
+                            subitems: definitions.length > 0
+                                ? definitions.map((d) => ({
+                                    label: d.label,
+                                    key: d.id,
+                                    handler: () => addNode(new FunctionCallNode(area, d)),
+                                }))
+                                : [{ label: '（请先创建函数定义）', key: 'no-def', handler: async () => {} }],
+                        },
+                    ],
+                };
+            }
+
+            // 节点 / 连线：删除
+            return {
+                searchBar: false,
+                list: [{
+                    label: 'Delete',
+                    key: 'delete',
+                    handler: async () => {
+                        if ('source' in context && 'target' in context) {
+                            await editor.removeConnection(context.id);
+                            return;
+                        }
+                        for (const c of editor.getConnections()) {
+                            if (c.source === context.id || c.target === context.id) {
+                                await editor.removeConnection(c.id);
+                            }
+                        }
+                        await editor.removeNode(context.id);
+                    },
+                }],
+            };
+        },
+    });
+
     // 使用 AreaExtensions 来配置插件
     AreaExtensions.selectableNodes(area, AreaExtensions.selector(), {
         accumulating: AreaExtensions.accumulateOnCtrl()
     });
 
     connection.addPreset(ConnectionPresets.classic.setup());
+    reactRender.addPreset(ReactPresets.contextMenu.setup());
 
     // 注册自定义节点组件
     reactRender.addPreset(ReactPresets.classic.setup({
         customize: {
+            node(context) {
+                if (context.payload instanceof FunctionDefinitionNode) {
+                    return FunctionDefinitionRender;
+                }
+                return ReactPresets.classic.Node;
+            },
             control(context) {
                 if (context.payload instanceof ButtonControl) {
                     return ButtonControlRender;
@@ -39,42 +128,107 @@ const createEditor = async (container: HTMLElement) => {
                 if (context.payload instanceof ParameterControl) {
                     return ParameterControlRender;
                 }
+                if (context.payload instanceof NameControl) {
+                    return NameControlRender;
+                }
+                if (context.payload instanceof InfoControl) {
+                    return InfoControlRender;
+                }
                 if (context.payload instanceof ClassicPreset.InputControl) {
-                    return Presets.classic.Control;
+                    return ReactPresets.classic.Control;
                 }
                 return null;
             }
         }
     }));
-    
 
     // 配置插件
     editor.use(area);
     area.use(connection);
+    area.use(contextMenu);
     area.use(reactRender);
     AreaExtensions.simpleNodesOrder(area);
 
-    // 添加示例节点
+    // 添加示例流程：输入 → 函数调用（引用函数定义）→ 返回
     const inputNode = new InputNode(area);
+    const definitionNode = new FunctionDefinitionNode(area, '图像生成');
+    const callNode = new FunctionCallNode(area, definitionNode);
     const outputNode = new OutputNode(area);
-    inputNode.addOutputSocket();
-    outputNode.addInputSocket();
 
+    inputNode.addParameter();
+    inputNode.addParameter();
+    definitionNode.addParameter();
+    definitionNode.addReturn();
+    outputNode.addReturn();
+    outputNode.addReturn();
 
     await editor.addNode(inputNode);
+    await editor.addNode(definitionNode);
+    await editor.addNode(callNode);
     await editor.addNode(outputNode);
 
-    console.log("节点已添加");
+    // 连接示例：输入参数 → 函数调用 → 返回
+    await editor.addConnection(new Connection<BaseNode, BaseNode>(inputNode, 'param_0', callNode, 'in_param_0'));
+    await editor.addConnection(new Connection<BaseNode, BaseNode>(inputNode, 'param_1', callNode, 'in_param_1'));
+    await editor.addConnection(new Connection<BaseNode, BaseNode>(callNode, 'out_return_0', outputNode, 'return_0'));
+    await editor.addConnection(new Connection<BaseNode, BaseNode>(callNode, 'out_return_1', outputNode, 'return_1'));
 
-    await area.translate(inputNode.id, { x: -150, y: 0 });
-    await area.translate(outputNode.id, { x: 150, y: 0 });
+    await area.translate(inputNode.id, { x: -620, y: 100 });
+    await area.translate(definitionNode.id, { x: -200, y: 0 });
+    await area.translate(callNode.id, { x: 420, y: 100 });
+    await area.translate(outputNode.id, { x: 700, y: 100 });
 
     setTimeout(() => {
         AreaExtensions.zoomAt(area, editor.getNodes());
     }, 1);
 
+    // 工具栏：方便添加节点
+    const toolbar = document.createElement('div');
+    toolbar.className = 'workflow-toolbar';
+    const addToolbarButton = (label: string, factory: () => BaseNode) => {
+        const button = document.createElement('button');
+        button.className = 'workflow-toolbar-button';
+        button.textContent = label;
+        button.addEventListener('pointerdown', (e) => e.stopPropagation());
+        button.addEventListener('contextmenu', (e) => e.stopPropagation());
+        button.addEventListener('click', async () => {
+            const node = factory();
+            await editor.addNode(node);
+            await area.translate(node.id, area.area.pointer);
+        });
+        toolbar.appendChild(button);
+    };
+    addToolbarButton('添加输入节点', () => new InputNode(area));
+    addToolbarButton('添加返回节点', () => new OutputNode(area));
+    addToolbarButton('添加函数定义', () => new FunctionDefinitionNode(area));
+    const callButton = document.createElement('button');
+    callButton.className = 'workflow-toolbar-button';
+    callButton.textContent = '添加函数调用';
+    callButton.addEventListener('pointerdown', (e) => e.stopPropagation());
+    callButton.addEventListener('click', async () => {
+        const def = editor.getNodes().find(
+            (n): n is FunctionDefinitionNode => n instanceof FunctionDefinitionNode
+        );
+        if (!def) {
+            console.warn('请先创建函数定义，再添加函数调用');
+            return;
+        }
+        await addNode(new FunctionCallNode(area, def));
+    });
+    toolbar.appendChild(callButton);
+    const clearButton = document.createElement('button');
+    clearButton.className = 'workflow-toolbar-button workflow-toolbar-clear';
+    clearButton.textContent = '清空画布';
+    clearButton.addEventListener('pointerdown', (e) => e.stopPropagation());
+    clearButton.addEventListener('click', () => void editor.clear());
+    toolbar.appendChild(clearButton);
+    container.appendChild(toolbar);
+
     return {
-        destroy: () => area.destroy(),
+        destroy: () => {
+            toolbar.remove();
+            area.destroy();
+        },
     };
 };
 


### PR DESCRIPTION
## 概述

实现 .flow 流程系统：函数定义是一个画布上的透明大矩形框，把画布上的一部分节点框起来；框内的输入节点和返回节点自动成为该函数的输入/输出（一个框内只能有一个输入节点和一个返回节点）。函数调用节点引用函数定义，其输入/输出数量与名称由被框住的输入/返回节点同步决定。一个大方框对应一个 Python 函数。

## 交互

- 工具栏/右键菜单可添加「函数定义」：有选中节点时自动生成包围框把选中节点框起来，否则创建空框；拖动标题移动、拖右下角缩放
- 框内成员按节点在画布上的位置实时判定：把节点拖进/拖出框、或缩放框，函数的参数/返回值都会实时变化
- 框内超过一个输入/返回节点时显示告警提示
- 「函数调用」子菜单列出所有函数定义；调用节点端口随定义自动同步
- 示例：一个「图像生成」函数框框住 输入(2参数) → 算子 → 返回(2返回值)，框外 输入/返回 节点通过函数调用节点使用该函数

## 改动

- frontend/ssui_components/src/shared/Nodes.tsx：FunctionDefinitionNode（透明矩形框 + 成员判定 + 同步）、FunctionCallNode（引用定义同步端口）、Input/Output/Operator 画布节点
- frontend/ssui_components/src/shared/Workflow.tsx：右键菜单/工具栏、框选生成、成员重算管道、示例流程
- frontend/ssui_components/src/shared/Workflow.css：透明矩形框样式

## 验证

- ssui_components、ssui-functional_ui 均通过 tsc && vite build
- 浏览器实测：框内输入节点加参数 -> 定义与调用节点同步 3 参数；把返回节点拖出框 -> 返回值变 0，拖回/放大框 -> 恢复；框内放两个输入节点 -> 显示只能有一个输入节点告警；框选选中节点生成函数正常