### PR TITLE
refactor(workflow): 函数定义改为画布透明矩形框，按位置框住节点

### DIFF
--- a/frontend/ssui_components/src/shared/Nodes.tsx
+++ b/frontend/ssui_components/src/shared/Nodes.tsx
@@ -1,7 +1,7 @@
-import type { ReactNode } from 'react';
+import type * as React from 'react';
 import { Button } from '@blueprintjs/core';
 import { ClassicPreset, GetSchemes, NodeEditor } from 'rete';
-import { Presets as ReactPresets, ReactArea2D, type RenderEmit } from 'rete-react-plugin';
+import { ReactArea2D, type RenderEmit } from 'rete-react-plugin';
 import {
     ContextMenuExtra,
 } from "rete-context-menu-plugin";
@@ -397,12 +397,18 @@ export class OperatorNode extends BaseNode {
     }
 }
 
-// ============ 函数定义节点（一个大方框 = 一个 Python 函数） ============
+// ============ 函数定义节点（透明大矩形框，框住画布上的一部分节点） ============
 
 export class FunctionDefinitionNode extends BaseNode {
     static counter = 0;
-    children: BaseNode[] = [];
+    boxWidth = 560;
+    boxHeight = 320;
+    inputNode?: InputNode;
+    outputNode?: OutputNode;
+    hasTooManyInputs = false;
+    hasTooManyOutputs = false;
     private callers: FunctionCallNode[] = [];
+    private lastSignature = '';
 
     constructor(
         area: AreaPlugin<Schemes, AreaExtra>,
@@ -412,15 +418,6 @@ export class FunctionDefinitionNode extends BaseNode {
         super(fnName);
         this.area = area;
 
-        // 内部的输入/返回节点：它们的参数/返回值就是这个函数的输入/输出
-        const refresh = () => {
-            this.syncSignature();
-            this.refresh();
-        };
-        const innerInput = new InputNode(undefined, refresh);
-        const innerOutput = new OutputNode(undefined, refresh);
-        this.children.push(innerInput, innerOutput);
-
         const nameControl = new NameControl(fnName, () => {});
         this.addControl('name', nameControl);
         nameControl.onChange = (value) => {
@@ -429,44 +426,20 @@ export class FunctionDefinitionNode extends BaseNode {
             this.syncCallers();
             this.refresh();
         };
-        this.addControl('addChild', new ButtonControl('添加子节点', () => this.addChild()));
         this.addControl('createCall', new ButtonControl('创建函数调用', () => this.createCall()));
-
-        // 默认一个参数、一个返回值
-        innerInput.addParameter();
-        innerOutput.addReturn();
-        this.syncSignature();
     }
 
-    getInnerInput(): InputNode {
-        return this.children.find((c): c is InputNode => c instanceof InputNode)!;
+    getArea(): AreaPlugin<Schemes, AreaExtra> | undefined {
+        return this.area;
     }
 
-    getInnerOutput(): OutputNode {
-        return this.children.find((c): c is OutputNode => c instanceof OutputNode)!;
+    // 框内输入/输出节点定义函数的参数与返回值
+    getParameters(): ParamSpec[] {
+        return this.inputNode?.getParameters() ?? [];
     }
 
-    addParameter(): ParamSpec {
-        return this.getInnerInput().addParameter();
-    }
-
-    removeParameter(key: string): void {
-        this.getInnerInput().removeParameter(key);
-    }
-
-    addReturn(): ParamSpec {
-        return this.getInnerOutput().addReturn();
-    }
-
-    removeReturn(key: string): void {
-        this.getInnerOutput().removeReturn(key);
-    }
-
-    addChild(): BaseNode {
-        const child = new OperatorNode(`算子 ${this.children.length - 1}`, () => this.refresh());
-        this.children.push(child);
-        this.refresh();
-        return child;
+    getReturns(): ParamSpec[] {
+        return this.outputNode?.getReturns() ?? [];
     }
 
     registerCaller(caller: FunctionCallNode): void {
@@ -479,32 +452,101 @@ export class FunctionDefinitionNode extends BaseNode {
         this.callers = this.callers.filter((c) => c !== caller);
     }
 
-    // 根据定义创建/更新调用节点，并放到定义右侧
+    // 依据节点在画布上的位置计算框内成员：
+    // 一个框内只能有一个输入节点和一个输出节点，它们定义函数的输入/输出
+    sync(): void {
+        const editor = this.getEditor();
+        const area = this.area;
+        if (!editor || !area) return;
+        const view = area.nodeViews.get(this.id);
+        if (!view) return;
+
+        const rect = {
+            x: view.position.x,
+            y: view.position.y,
+            w: this.boxWidth,
+            h: this.boxHeight,
+        };
+        const inputNodes: InputNode[] = [];
+        const outputNodes: OutputNode[] = [];
+
+        for (const node of editor.getNodes()) {
+            if (node === this) continue;
+            const nodeView = area.nodeViews.get(node.id);
+            if (!nodeView) continue;
+            const w = nodeView.element.offsetWidth || 180;
+            const h = nodeView.element.offsetHeight || 120;
+            const cx = nodeView.position.x + w / 2;
+            const cy = nodeView.position.y + h / 2;
+            if (cx < rect.x || cx > rect.x + rect.w || cy < rect.y || cy > rect.y + rect.h) {
+                continue;
+            }
+            if (node instanceof InputNode) inputNodes.push(node);
+            else if (node instanceof OutputNode) outputNodes.push(node);
+        }
+
+        this.hasTooManyInputs = inputNodes.length > 1;
+        this.hasTooManyOutputs = outputNodes.length > 1;
+        const inputNode = inputNodes[0];
+        const outputNode = outputNodes[0];
+
+        const params = inputNode?.getParameters() ?? [];
+        const returns = outputNode?.getReturns() ?? [];
+        const signature =
+            `${this.label}|` +
+            `${inputNode?.id ?? '-'}|${params.map((p) => `${p.key}:${p.name}:${p.type}`).join(',')}|` +
+            `${outputNode?.id ?? '-'}|${returns.map((r) => `${r.key}:${r.name}:${r.type}`).join(',')}|` +
+            `${this.boxWidth}x${this.boxHeight}|${this.hasTooManyInputs}|${this.hasTooManyOutputs}`;
+
+        if (signature === this.lastSignature) return;
+        this.lastSignature = signature;
+        this.inputNode = inputNode;
+        this.outputNode = outputNode;
+        this.syncCallers();
+        void area.update('node', this.id);
+    }
+
+    // 按选中节点的最小包围盒调整矩形，把节点框起来
+    fitToNodes(nodes: BaseNode[]): void {
+        const area = this.area;
+        if (!area) return;
+        let minX = Infinity;
+        let minY = Infinity;
+        let maxX = -Infinity;
+        let maxY = -Infinity;
+        for (const node of nodes) {
+            const view = area.nodeViews.get(node.id);
+            if (!view) continue;
+            const w = view.element.offsetWidth || 180;
+            const h = view.element.offsetHeight || 120;
+            minX = Math.min(minX, view.position.x);
+            minY = Math.min(minY, view.position.y);
+            maxX = Math.max(maxX, view.position.x + w);
+            maxY = Math.max(maxY, view.position.y + h);
+        }
+        if (minX === Infinity) return;
+        const padding = 46;
+        this.boxWidth = Math.max(240, maxX - minX + padding * 2);
+        this.boxHeight = Math.max(140, maxY - minY + padding * 2);
+        void area.translate(this.id, { x: minX - padding, y: minY - padding });
+    }
+
+    // 根据定义创建调用节点，放到定义右侧
     async createCall(): Promise<FunctionCallNode> {
         const caller = new FunctionCallNode(this.area!, this);
         await this.area!.parentScope(NodeEditor).addNode(caller);
         const pos = this.area!.nodeViews.get(this.id)?.position;
         await this.area!.translate(caller.id, {
-            x: (pos?.x ?? 0) + 300,
+            x: (pos?.x ?? 0) + this.boxWidth + 80,
             y: pos?.y ?? 0,
         });
         return caller;
     }
 
-    // 把内部输入节点的参数同步为外层输入端口，内部返回节点同步为外层输出端口
-    private syncSignature(): void {
-        this.syncPortsFromInner(
-            this.getInnerInput().getParameters(),
-            this.getInnerOutput().getReturns()
-        );
-        this.syncCallers();
-    }
-
-    // 函数签名/名称变化后，同步所有引用它的调用节点
+    // 函数名/签名变化后，同步所有引用它的调用节点
     private syncCallers(): void {
         this.callers.forEach((caller) => {
-            caller.syncSignature();
-            if (caller.getEditor()?.getNode(caller.id)) {
+            if (caller.syncSignature()) {
                 void this.area?.update('node', caller.id);
             }
         });
@@ -514,6 +556,8 @@ export class FunctionDefinitionNode extends BaseNode {
 // ============ 函数调用节点（端口数量由被调用的函数定义决定） ============
 
 export class FunctionCallNode extends BaseNode {
+    private lastSignature = '';
+
     constructor(
         area: AreaPlugin<Schemes, AreaExtra>,
         public definition: FunctionDefinitionNode
@@ -526,116 +570,76 @@ export class FunctionCallNode extends BaseNode {
         this.syncSignature();
     }
 
-    // 从函数定义同步名称和端口：输入端口 = 定义的参数，输出端口 = 定义的返回值
-    syncSignature(): void {
+    // 从函数定义同步名称和端口：输入端口 = 定义内输入节点的参数，输出端口 = 定义内返回节点的返回值
+    syncSignature(): boolean {
+        const params = this.definition.getParameters();
+        const returns = this.definition.getReturns();
+        const signature =
+            `${this.definition.label}|` +
+            `${params.map((p) => `${p.key}:${p.name}:${p.type}`).join(',')}|` +
+            `${returns.map((r) => `${r.key}:${r.name}:${r.type}`).join(',')}`;
+        if (signature === this.lastSignature) return false;
+        this.lastSignature = signature;
         this.label = this.definition.label;
-        this.syncPortsFromInner(
-            this.definition.getInnerInput().getParameters(),
-            this.definition.getInnerOutput().getReturns()
-        );
+        this.syncPortsFromInner(params, returns);
+        return true;
     }
 }
 
-// ============ 函数定义节点的自定义渲染（大矩形框） ============
-
-function renderControl(control: ClassicPreset.Control): ReactNode | null {
-    if (control instanceof ButtonControl) {
-        return <ButtonControlRender data={control} />;
-    }
-    if (control instanceof ParameterControl) {
-        return <ParameterControlRender data={control} />;
-    }
-    if (control instanceof NameControl) {
-        return <NameControlRender data={control} />;
-    }
-    if (control instanceof InfoControl) {
-        return <InfoControlRender data={control} />;
-    }
-    return null;
-}
-
-function ChildBlock({ child }: { child: BaseNode }) {
-    const entries = Object.entries(child.controls).filter(([, control]) => control);
-    const addEntry = entries.find(([key]) => key === 'add');
-    const rest = entries.filter(([key]) => key !== 'add');
-    const ordered = addEntry ? [...rest, addEntry] : rest;
-
-    return (
-        <div className="flow-child-node">
-            <div className="flow-child-title">{child.label}</div>
-            {ordered.map(([, control]) => (
-                <div className="flow-child-control" key={control!.id}>
-                    {renderControl(control!)}
-                </div>
-            ))}
-        </div>
-    );
-}
+// ============ 函数定义节点的自定义渲染（透明矩形框） ============
 
 export function FunctionDefinitionRender(props: {
     data: BaseNode;
     emit: RenderEmit<Schemes>;
 }): React.JSX.Element {
     const node = props.data as FunctionDefinitionNode;
-    const inputs = Object.entries(node.inputs).filter(([, input]) => input);
-    const outputs = Object.entries(node.outputs).filter(([, output]) => output);
     const nameControl = node.controls['name'];
-    const addChildControl = node.controls['addChild'];
     const createCallControl = node.controls['createCall'];
+    const params = node.getParameters().length;
+    const returns = node.getReturns().length;
+
+    const onResizePointerDown = (e: React.PointerEvent) => {
+        e.stopPropagation();
+        e.preventDefault();
+        const area = node.getArea();
+        if (!area) return;
+        const k = area.area.transform.k || 1;
+        const startX = e.clientX;
+        const startY = e.clientY;
+        const startW = node.boxWidth;
+        const startH = node.boxHeight;
+        const move = (ev: PointerEvent) => {
+            node.boxWidth = Math.max(240, startW + (ev.clientX - startX) / k);
+            node.boxHeight = Math.max(140, startH + (ev.clientY - startY) / k);
+            node.sync();
+            void area.update('node', node.id);
+        };
+        const up = () => {
+            window.removeEventListener('pointermove', move);
+            window.removeEventListener('pointerup', up);
+        };
+        window.addEventListener('pointermove', move);
+        window.addEventListener('pointerup', up);
+    };
 
     return (
-        <div className={`flow-function-node${node.selected ? ' selected' : ''}`}>
-            <div className="flow-function-header">
+        <div
+            className={`flow-function-def${node.selected ? ' selected' : ''}`}
+            style={{ width: node.boxWidth, height: node.boxHeight }}
+        >
+            <div className="flow-def-header">
                 <span className="flow-function-badge">函数定义</span>
                 {nameControl instanceof NameControl && <NameControlRender data={nameControl} />}
-                <span className="flow-function-meta">
-                    {inputs.length} 参数 · {outputs.length} 返回值
-                </span>
-            </div>
-
-            <div className="flow-function-children">
-                {node.children.map((child) => (
-                    <ChildBlock key={child.id} child={child} />
-                ))}
-            </div>
-
-            <div className="flow-function-footer">
-                {addChildControl instanceof ButtonControl && <ButtonControlRender data={addChildControl} />}
                 {createCallControl instanceof ButtonControl && <ButtonControlRender data={createCallControl} />}
+                <span className="flow-function-meta">{params} 参数 · {returns} 返回值</span>
             </div>
-
-            <div className="flow-function-ports">
-                <div className="flow-function-inputs">
-                    {inputs.map(([key, input]) => (
-                        <div className="flow-port-row" key={key}>
-                            <ReactPresets.classic.RefSocket
-                                name="input-socket"
-                                side="input"
-                                socketKey={key}
-                                nodeId={node.id}
-                                emit={props.emit}
-                                payload={input!.socket}
-                            />
-                            <span className="flow-port-label">{input!.label}</span>
-                        </div>
-                    ))}
-                </div>
-                <div className="flow-function-outputs">
-                    {outputs.map(([key, output]) => (
-                        <div className="flow-port-row" key={key}>
-                            <span className="flow-port-label">{output!.label}</span>
-                            <ReactPresets.classic.RefSocket
-                                name="output-socket"
-                                side="output"
-                                socketKey={key}
-                                nodeId={node.id}
-                                emit={props.emit}
-                                payload={output!.socket}
-                            />
-                        </div>
-                    ))}
-                </div>
-            </div>
+            {node.hasTooManyInputs && (
+                <div className="flow-def-warning">⚠ 一个函数内只能有一个输入节点</div>
+            )}
+            {node.hasTooManyOutputs && (
+                <div className="flow-def-warning">⚠ 一个函数内只能有一个返回节点</div>
+            )}
+            <div className="flow-def-resize" onPointerDown={onResizePointerDown} />
         </div>
     );
 }

--- a/frontend/ssui_components/src/shared/Workflow.css
+++ b/frontend/ssui_components/src/shared/Workflow.css
@@ -45,33 +45,41 @@
     background: #93505f;
 }
 
-/* ============ 函数调用节点（大矩形框） ============ */
+/* ============ 函数定义节点（透明大矩形框） ============ */
 
-.flow-function-node {
-    width: 380px;
+.flow-function-def {
+    position: relative;
     box-sizing: border-box;
-    background: #23273f;
-    border: 2px solid #4e58bf;
-    border-radius: 12px;
+    background: rgba(78, 88, 191, 0.07);
+    border: 2px dashed rgba(122, 134, 255, 0.8);
+    border-radius: 14px;
+    pointer-events: none;
+    user-select: none;
     color: #fff;
     font-family: Arial, sans-serif;
-    user-select: none;
     line-height: initial;
-    padding: 8px 12px 12px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
 }
 
-.flow-function-node.selected {
-    background: #343a5e;
+.flow-function-def.selected {
     border-color: #ffd92c;
+    background: rgba(255, 217, 44, 0.06);
 }
 
-.flow-function-header {
+.flow-def-header {
+    position: absolute;
+    top: 8px;
+    left: 12px;
+    right: 12px;
     display: flex;
     align-items: center;
     gap: 8px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+    padding: 3px 8px;
+    background: rgba(28, 31, 48, 0.92);
+    border: 1px solid rgba(122, 134, 255, 0.6);
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    pointer-events: auto;
+    cursor: move;
 }
 
 .flow-function-badge {
@@ -109,34 +117,30 @@
     white-space: nowrap;
 }
 
-.flow-function-children {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-    padding: 10px 0;
+.flow-def-warning {
+    position: absolute;
+    top: 46px;
+    left: 14px;
+    font-size: 12px;
+    color: #ffb366;
+    pointer-events: none;
 }
 
-.flow-child-node {
-    flex: 1;
-    min-width: 140px;
-    box-sizing: border-box;
-    background: #2c3150;
-    border: 1px solid #4e58bf;
-    border-radius: 8px;
-    padding: 6px 8px;
+.flow-def-resize {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    width: 18px;
+    height: 18px;
+    cursor: nwse-resize;
+    pointer-events: auto;
+    border-right: 3px solid rgba(122, 134, 255, 0.9);
+    border-bottom: 3px solid rgba(122, 134, 255, 0.9);
+    border-bottom-right-radius: 12px;
 }
 
-.flow-child-title {
-    font-size: 13px;
-    font-weight: bold;
-    color: #dfe3ff;
-    padding-bottom: 4px;
-    margin-bottom: 4px;
-    border-bottom: 1px dashed rgba(255, 255, 255, 0.2);
-}
-
-.flow-child-control {
-    margin: 3px 0;
+.flow-def-resize:hover {
+    border-color: #ffd92c;
 }
 
 .flow-param-row {
@@ -159,51 +163,6 @@
 .flow-param-row input:focus {
     outline: none;
     border-color: #8f97ea;
-}
-
-.flow-function-footer {
-    display: flex;
-    gap: 6px;
-    padding-top: 6px;
-    border-top: 1px solid rgba(255, 255, 255, 0.15);
-}
-
-.flow-function-ports {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    margin-top: 6px;
-}
-
-.flow-function-inputs,
-.flow-function-outputs {
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-}
-
-.flow-port-row {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 13px;
-    color: #dfe3ff;
-}
-
-.flow-function-inputs .flow-port-row {
-    margin-left: -10px;
-}
-
-.flow-function-outputs .flow-port-row {
-    justify-content: flex-end;
-    margin-right: -10px;
-}
-
-.flow-port-label {
-    max-width: 110px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
 .flow-info-text {

--- a/frontend/ssui_components/src/shared/Workflow.tsx
+++ b/frontend/ssui_components/src/shared/Workflow.tsx
@@ -21,6 +21,7 @@ import {
     InputNode,
     NameControl,
     NameControlRender,
+    OperatorNode,
     OutputNode,
     ParameterControl,
     ParameterControlRender,
@@ -47,6 +48,27 @@ const createEditor = async (container: HTMLElement) => {
         await area.translate(node.id, area.area.pointer);
     };
 
+    const syncDefinitions = () => {
+        for (const node of editor.getNodes()) {
+            if (node instanceof FunctionDefinitionNode) {
+                node.sync();
+            }
+        }
+    };
+
+    // 创建函数定义：有选中节点时按选中节点生成包围框，否则创建空框
+    const createDefinition = async () => {
+        const def = new FunctionDefinitionNode(area);
+        await editor.addNode(def);
+        const selected = editor.getNodes().filter((n) => n.selected && n !== def);
+        if (selected.length > 0) {
+            def.fitToNodes(selected);
+        } else {
+            await area.translate(def.id, area.area.pointer);
+        }
+        syncDefinitions();
+    };
+
     const contextMenu = new ContextMenuPlugin<Schemes>({
         items: (context) => {
             if (context === 'root') {
@@ -58,7 +80,8 @@ const createEditor = async (container: HTMLElement) => {
                     list: [
                         { label: '输入节点', key: 'input', handler: () => addNode(new InputNode(area)) },
                         { label: '返回节点', key: 'output', handler: () => addNode(new OutputNode(area)) },
-                        { label: '函数定义', key: 'definition', handler: () => addNode(new FunctionDefinitionNode(area)) },
+                        { label: '算子节点', key: 'operator', handler: () => addNode(new OperatorNode('算子')) },
+                        { label: '函数定义（框选节点）', key: 'definition', handler: () => createDefinition() },
                         {
                             label: '函数调用',
                             key: 'call',
@@ -149,34 +172,88 @@ const createEditor = async (container: HTMLElement) => {
     area.use(reactRender);
     AreaExtensions.simpleNodesOrder(area);
 
-    // 添加示例流程：输入 → 函数调用（引用函数定义）→ 返回
-    const inputNode = new InputNode(area);
+    // 右键前选中的节点快照：右键会清空选中，菜单打开前恢复，便于“框选节点生成函数”
+    let rightClickSelection: string[] = [];
+
+    // 节点/矩形移动、增删、重渲染时，重算函数定义框内的成员
+    area.addPipe((context) => {
+        if (context && typeof context === 'object' && 'type' in context) {
+            const type = (context as { type: string }).type;
+            if (type === 'pointerdown') {
+                const event = (context as { data?: { event?: PointerEvent } }).data?.event;
+                if (event?.button === 2) {
+                    rightClickSelection = editor.getNodes()
+                        .filter((n) => n.selected)
+                        .map((n) => n.id);
+                }
+            }
+            if (type === 'contextmenu') {
+                rightClickSelection.forEach((id) => {
+                    const node = editor.getNode(id);
+                    if (node && !node.selected) {
+                        node.selected = true;
+                        void area.update('node', id);
+                    }
+                });
+            }
+            if (
+                type === 'render' ||
+                type === 'nodetranslated' ||
+                type === 'nodecreated' ||
+                type === 'noderemoved'
+            ) {
+                syncDefinitions();
+            }
+        }
+        return context;
+    });
+
+    // 示例流程：一个函数定义框把 输入 → 算子 → 返回 框起来，
+    // 框外的 输入/返回 节点通过函数调用节点使用该函数
     const definitionNode = new FunctionDefinitionNode(area, '图像生成');
+    definitionNode.boxWidth = 900;
+    definitionNode.boxHeight = 340;
+
+    const innerInput = new InputNode(area);
+    innerInput.addParameter();
+    innerInput.addParameter();
+    const operator = new OperatorNode('采样');
+    const innerOutput = new OutputNode(area);
+    innerOutput.addReturn();
+    innerOutput.addReturn();
+
     const callNode = new FunctionCallNode(area, definitionNode);
-    const outputNode = new OutputNode(area);
 
-    inputNode.addParameter();
-    inputNode.addParameter();
-    definitionNode.addParameter();
-    definitionNode.addReturn();
-    outputNode.addReturn();
-    outputNode.addReturn();
+    const topInput = new InputNode(area);
+    topInput.addParameter();
+    topInput.addParameter();
+    const topOutput = new OutputNode(area);
+    topOutput.addReturn();
+    topOutput.addReturn();
 
-    await editor.addNode(inputNode);
     await editor.addNode(definitionNode);
+    await editor.addNode(innerInput);
+    await editor.addNode(operator);
+    await editor.addNode(innerOutput);
     await editor.addNode(callNode);
-    await editor.addNode(outputNode);
+    await editor.addNode(topInput);
+    await editor.addNode(topOutput);
 
-    // 连接示例：输入参数 → 函数调用 → 返回
-    await editor.addConnection(new Connection<BaseNode, BaseNode>(inputNode, 'param_0', callNode, 'in_param_0'));
-    await editor.addConnection(new Connection<BaseNode, BaseNode>(inputNode, 'param_1', callNode, 'in_param_1'));
-    await editor.addConnection(new Connection<BaseNode, BaseNode>(callNode, 'out_return_0', outputNode, 'return_0'));
-    await editor.addConnection(new Connection<BaseNode, BaseNode>(callNode, 'out_return_1', outputNode, 'return_1'));
+    await area.translate(definitionNode.id, { x: -560, y: 20 });
+    await area.translate(innerInput.id, { x: -520, y: 150 });
+    await area.translate(operator.id, { x: -250, y: 180 });
+    await area.translate(innerOutput.id, { x: 20, y: 150 });
+    await area.translate(callNode.id, { x: 520, y: 200 });
+    await area.translate(topInput.id, { x: -1040, y: 250 });
+    await area.translate(topOutput.id, { x: 840, y: 250 });
 
-    await area.translate(inputNode.id, { x: -620, y: 100 });
-    await area.translate(definitionNode.id, { x: -200, y: 0 });
-    await area.translate(callNode.id, { x: 420, y: 100 });
-    await area.translate(outputNode.id, { x: 700, y: 100 });
+    // 连接示例：顶层输入参数 → 函数调用 → 顶层返回
+    await editor.addConnection(new Connection<BaseNode, BaseNode>(topInput, 'param_0', callNode, 'in_param_0'));
+    await editor.addConnection(new Connection<BaseNode, BaseNode>(topInput, 'param_1', callNode, 'in_param_1'));
+    await editor.addConnection(new Connection<BaseNode, BaseNode>(callNode, 'out_return_0', topOutput, 'return_0'));
+    await editor.addConnection(new Connection<BaseNode, BaseNode>(callNode, 'out_return_1', topOutput, 'return_1'));
+
+    syncDefinitions();
 
     setTimeout(() => {
         AreaExtensions.zoomAt(area, editor.getNodes());
@@ -185,22 +262,19 @@ const createEditor = async (container: HTMLElement) => {
     // 工具栏：方便添加节点
     const toolbar = document.createElement('div');
     toolbar.className = 'workflow-toolbar';
-    const addToolbarButton = (label: string, factory: () => BaseNode) => {
+    const addToolbarButton = (label: string, handler: () => void | Promise<void>) => {
         const button = document.createElement('button');
         button.className = 'workflow-toolbar-button';
         button.textContent = label;
         button.addEventListener('pointerdown', (e) => e.stopPropagation());
         button.addEventListener('contextmenu', (e) => e.stopPropagation());
-        button.addEventListener('click', async () => {
-            const node = factory();
-            await editor.addNode(node);
-            await area.translate(node.id, area.area.pointer);
-        });
+        button.addEventListener('click', () => void handler());
         toolbar.appendChild(button);
     };
-    addToolbarButton('添加输入节点', () => new InputNode(area));
-    addToolbarButton('添加返回节点', () => new OutputNode(area));
-    addToolbarButton('添加函数定义', () => new FunctionDefinitionNode(area));
+    addToolbarButton('添加输入节点', () => addNode(new InputNode(area)));
+    addToolbarButton('添加返回节点', () => addNode(new OutputNode(area)));
+    addToolbarButton('添加算子节点', () => addNode(new OperatorNode('算子')));
+    addToolbarButton('添加函数定义', () => createDefinition());
     const callButton = document.createElement('button');
     callButton.className = 'workflow-toolbar-button';
     callButton.textContent = '添加函数调用';


### PR DESCRIPTION
## 概述

实现 .flow 流程系统：函数定义是一个画布上的透明大矩形框，把画布上的一部分节点框起来；框内的输入节点和返回节点自动成为该函数的输入/输出（一个框内只能有一个输入节点和一个返回节点）。函数调用节点引用函数定义，其输入/输出数量与名称由被框住的输入/返回节点同步决定。一个大方框对应一个 Python 函数。

## 交互

- 透明矩形框渲染在节点下层，不遮挡框内节点；拖动标题栏移动、拖右下角缩放
- 拖动函数框时，框内节点跟随一起移动
- 输入/返回节点去冗余：参数名/类型直接写在端口旁（输入节点在右侧端口、返回节点在左侧端口），不再有下方单独的参数名输入行
- Shift + 点击多选节点，拖动任意选中节点时整组一起移动（无需在拖拽时持续按住 Shift）
- 框内成员按节点位置实时判定：拖进/拖出框、缩放框，函数的参数/返回值实时变化；框内超过一个输入/返回节点时显示告警
- 「函数调用」子菜单列出所有函数定义；右键「函数定义（框选节点）」可把选中节点用包围框框起来
- 示例：一个「图像生成」函数框框住 输入(2参数) → 算子 → 返回(2返回值)，框外 输入/返回 节点通过函数调用节点使用该函数

## 改动

- frontend/ssui_components/src/shared/Nodes.tsx：FunctionDefinitionNode（透明矩形框 + 成员判定 + 拖动成员 + 同步）、FunctionCallNode（引用定义同步端口）、Input/Output 节点端口旁内联编辑渲染、Operator 画布节点
- frontend/ssui_components/src/shared/Workflow.tsx：框置底渲染、框拖动联动成员、Shift 多选与保持多选、右键菜单/工具栏、成员重算管道、示例流程
- frontend/ssui_components/src/shared/Workflow.css：透明矩形框与端口行样式

## 验证

- ssui_components、ssui-functional_ui 均通过 tsc && vite build
- 浏览器实测：框内输入节点加参数 -> 定义与调用节点同步；把返回节点拖出框 -> 返回值归零，拖回/放大框 -> 恢复；框内两个输入节点 -> 告警提示；拖动函数框，框内节点位移与框一致（120,90）；Shift 多选后拖动，两个节点位移一致（50,70）；参数名在端口旁直接编辑并同步调用节点
