### PR TITLE
fix(model): 恢复预制模型组设计（含配套模型整套下载）

### DIFF
--- a/desktop/src/components/ModelAdding/PresetModels/index.tsx
+++ b/desktop/src/components/ModelAdding/PresetModels/index.tsx
@@ -5,6 +5,14 @@ import { useTranslation } from 'react-i18next';
 import TaskService from '../../../services/TaskService';
 import { getApiBaseUrl } from '../../../services/apiBase';
 
+interface PresetModelMember {
+    name: string;
+    source: string;
+    type?: string;
+    base?: string;
+    description?: string;
+}
+
 interface PresetModel {
     id: string;
     name: string;
@@ -14,6 +22,8 @@ interface PresetModel {
     description: string;
     imageUrl?: string;
     size?: string;
+    /** 模型组包含的成员（主模型 + 配套辅助模型） */
+    models?: PresetModelMember[];
 }
 
 interface PresetModelsProps {
@@ -24,16 +34,22 @@ const fallbackPresets: PresetModel[] = [
     {
         id: '001-flux-preset',
         name: 'Flux Model Preset',
-        type: 'Flux',
+        type: 'Main',
         base: 'flux',
-        source: 'InvokeAI/flux_schnell_quantized',
+        source: 'InvokeAI/flux_schnell::transformer/bnb_nf4/flux1-schnell-bnb_nf4.safetensors',
         description: [
             'FLUX Schnell (Quantized)',
             'clip-vit-large-patch14',
             't5_bnb_int8_quantized_encoder',
             'Flux Vae'
-        ].join(' / '),
-        imageUrl: 'https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f905bc28-9db6-4f83-85ae-93c94718881d/anim=false,width=450/NfX8MYg-_nTv_PpQBNJSr.jpeg'
+        ].join(' · '),
+        imageUrl: 'https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f905bc28-9db6-4f83-85ae-93c94718881d/anim=false,width=450/NfX8MYg-_nTv_PpQBNJSr.jpeg',
+        models: [
+            { name: 'FLUX Schnell (Quantized)', source: 'InvokeAI/flux_schnell::transformer/bnb_nf4/flux1-schnell-bnb_nf4.safetensors', type: 'main', base: 'flux' },
+            { name: 't5_bnb_int8_quantized_encoder', source: 'InvokeAI/t5-v1_1-xxl::bnb_llm_int8', type: 't5_encoder', base: 'any' },
+            { name: 'clip-vit-large-patch14', source: 'InvokeAI/clip-vit-large-patch14', type: 'clip_vision', base: 'any' },
+            { name: 'FLUX.1-schnell_ae', source: 'black-forest-labs/FLUX.1-schnell::ae.safetensors', type: 'vae', base: 'flux' }
+        ]
     }
 ];
 
@@ -44,7 +60,9 @@ export const PresetModels: React.FC<PresetModelsProps> = ({ onModelSelect }) => 
     const [loadError, setLoadError] = useState<string | null>(null);
     const [downloading, setDownloading] = useState<{ [id: string]: number }>({});
     const taskService = useRef(TaskService.getInstance());
-    const taskIds = useRef<{ [modelId: string]: string }>({});
+    const groupTaskIds = useRef<{ [groupId: string]: string[] }>({});
+    const memberProgress = useRef<{ [taskId: string]: number }>({});
+    const memberDone = useRef<{ [taskId: string]: boolean }>({});
 
     useEffect(() => {
         const fetchPresets = async () => {
@@ -70,21 +88,26 @@ export const PresetModels: React.FC<PresetModelsProps> = ({ onModelSelect }) => 
     }, []);
 
     useEffect(() => {
-        // 通过任务队列的 task_update 推送更新下载进度
+        // 通过任务队列的 task_update 推送更新整组下载进度（各成员进度的平均）
         const unsubscribe = taskService.current.subscribe((task) => {
             if (task.kind !== 'download') return;
-            for (const [modelId, taskId] of Object.entries(taskIds.current)) {
-                if (taskId === task.id) {
-                    if (task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled') {
-                        delete taskIds.current[modelId];
-                        setDownloading(prev => {
-                            const next = { ...prev };
-                            delete next[modelId];
-                            return next;
-                        });
-                    } else {
-                        setDownloading(prev => ({ ...prev, [modelId]: task.progress }));
-                    }
+            for (const [groupId, taskIds] of Object.entries(groupTaskIds.current)) {
+                if (!taskIds.includes(task.id)) continue;
+                memberProgress.current[task.id] = task.status === 'completed' ? 100 : task.progress;
+                if (task.status === 'completed' || task.status === 'failed' || task.status === 'cancelled') {
+                    memberDone.current[task.id] = true;
+                }
+                const values = taskIds.map(id => memberProgress.current[id] ?? 0);
+                const progress = Math.round(values.reduce((sum, v) => sum + v, 0) / values.length);
+                setDownloading(prev => ({ ...prev, [groupId]: progress }));
+
+                if (taskIds.every(id => memberDone.current[id])) {
+                    delete groupTaskIds.current[groupId];
+                    setDownloading(prev => {
+                        const next = { ...prev };
+                        delete next[groupId];
+                        return next;
+                    });
                 }
             }
         });
@@ -93,19 +116,26 @@ export const PresetModels: React.FC<PresetModelsProps> = ({ onModelSelect }) => 
 
     const handleDownload = async (model: PresetModel) => {
         onModelSelect?.(model);
+        const members = model.models && model.models.length > 0
+            ? model.models
+            : [{ name: model.name, source: model.source }];
         setDownloading(prev => ({ ...prev, [model.id]: 0 }));
-        try {
-            const isUrl = model.source.startsWith('http://') || model.source.startsWith('https://');
-            const taskId = await taskService.current.createDownloadTask(
-                'preset',
-                model.name,
-                isUrl ? model.source : undefined,
-                isUrl ? undefined : model.source
-            );
-            taskIds.current[model.id] = taskId;
-        } catch (error) {
-            console.error('预设模型下载失败:', error);
+        const taskIds: string[] = [];
+        for (const member of members) {
+            try {
+                const isUrl = member.source.startsWith('http://') || member.source.startsWith('https://');
+                const taskId = await taskService.current.createDownloadTask(
+                    'preset',
+                    `${model.name} · ${member.name}`,
+                    isUrl ? member.source : undefined,
+                    isUrl ? undefined : member.source
+                );
+                taskIds.push(taskId);
+            } catch (error) {
+                console.error(`预设模型成员下载失败 (${member.name}):`, error);
+            }
         }
+        groupTaskIds.current[model.id] = taskIds;
     };
 
     if (loading && presets.length === 0) {
@@ -122,6 +152,7 @@ export const PresetModels: React.FC<PresetModelsProps> = ({ onModelSelect }) => 
                 {presets.map(model => {
                     const progress = downloading[model.id];
                     const isDownloading = progress !== undefined;
+                    const memberNames = (model.models || []).map(m => m.name);
                     return (
                         <div className={styles.card} key={model.id}>
                             <div className={styles.type}>{model.base || model.type}</div>
@@ -156,12 +187,12 @@ export const PresetModels: React.FC<PresetModelsProps> = ({ onModelSelect }) => 
                                 <Tooltip
                                     content={
                                         <div className={styles.tooltip}>
-                                            {model.description.split('·').map((line, index) => (
-                                                <div key={index} className={styles.tooltipItem}>{line.trim()}</div>
-                                            ))}
-                                            {model.size && model.size !== model.description && (
-                                                <div className={styles.tooltipItem}>{model.size}</div>
+                                            {model.description && (
+                                                <div className={styles.tooltipItem}>{model.description}</div>
                                             )}
+                                            {memberNames.map((name, index) => (
+                                                <div key={index} className={styles.tooltipItem}>{name}</div>
+                                            ))}
                                         </div>
                                     }
                                     position="right"

--- a/desktop/src/components/ModelAdding/PresetModels/index.tsx
+++ b/desktop/src/components/ModelAdding/PresetModels/index.tsx
@@ -156,7 +156,9 @@ export const PresetModels: React.FC<PresetModelsProps> = ({ onModelSelect }) => 
                                 <Tooltip
                                     content={
                                         <div className={styles.tooltip}>
-                                            <div className={styles.tooltipItem}>{model.description}</div>
+                                            {model.description.split('·').map((line, index) => (
+                                                <div key={index} className={styles.tooltipItem}>{line.trim()}</div>
+                                            ))}
                                             {model.size && model.size !== model.description && (
                                                 <div className={styles.tooltipItem}>{model.size}</div>
                                             )}

--- a/server/model_service.py
+++ b/server/model_service.py
@@ -296,3 +296,62 @@ class ModelService:
         thread.start()
 
         return {"message": "Download started"}
+
+    async def hf_file_download(
+        self,
+        repo_id: str,
+        filename: str,
+        local_dir: str,
+        client_id: str,
+        request_uuid: str,
+        callback: Callable[[str, str, Dict[str, Any]], None],
+        finish_callback: Callable[[str, str, Dict[str, Any]], None],
+    ):
+        """下载 HuggingFace 仓库中的单个文件（处理 starter model 的 repo::path 来源）。"""
+        loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
+
+        def download_thread():
+            from huggingface_hub import hf_hub_download
+            from tqdm.auto import tqdm
+
+            class download_progress_callback(tqdm):
+                def __init__(self, *args, **kwargs):
+                    super().__init__(*args, **kwargs)
+                    self.client_id = client_id
+                    self.request_uuid = request_uuid
+
+                def update(self, n=1):
+                    super().update(n)
+                    loop.call_soon_threadsafe(
+                        callback,
+                        self.client_id,
+                        self.request_uuid,
+                        "download_progress",
+                        {
+                            "progress": self.n / self.total * 100 if self.total else 0,
+                            "current": self.n,
+                            "total": self.total,
+                            "speed": self.format_dict.get("rate", 0),
+                            "eta": self.format_dict.get("eta", 0),
+                        },
+                    )
+
+                def close(self):
+                    super().close()
+                    loop.call_soon_threadsafe(
+                        finish_callback,
+                        self.client_id,
+                        self.request_uuid,
+                    )
+
+            hf_hub_download(
+                repo_id=repo_id,
+                filename=filename,
+                local_dir=local_dir,
+                tqdm_class=download_progress_callback,
+            )
+
+        thread = threading.Thread(target=download_thread)
+        thread.start()
+
+        return {"message": "Download started"}

--- a/server/routes/model_routes.py
+++ b/server/routes/model_routes.py
@@ -134,9 +134,28 @@ PRESET_IMAGE_URLS = {
 }
 
 
-def _preset_to_dict(model) -> dict:
+def _starter_to_preset_group(model) -> dict:
+    """把一个 starter model（含依赖）展开为一组预设模型。
+
+    模型组 = 主模型 + 其依赖的辅助模型（如 Flux 的 CLIP/T5/VAE），
+    一组下载完即可直接出图。
+    """
     base = getattr(model, "base", "")
     model_type = getattr(model, "type", "")
+    members = [model] + list(getattr(model, "dependencies", None) or [])
+    member_items = []
+    for member in members:
+        m_base = getattr(member, "base", "")
+        m_type = getattr(member, "type", "")
+        member_items.append(
+            {
+                "name": member.name,
+                "source": member.source,
+                "type": m_type.value if hasattr(m_type, "value") else str(m_type),
+                "base": m_base.value if hasattr(m_base, "value") else str(m_base),
+                "description": member.description,
+            }
+        )
     return {
         "id": model.name.lower().replace(" ", "-").replace("(", "").replace(")", ""),
         "name": model.name,
@@ -146,26 +165,21 @@ def _preset_to_dict(model) -> dict:
         "description": model.description,
         "size": model.description,
         "imageUrl": PRESET_IMAGE_URLS.get(model.name, ""),
+        "models": member_items,
     }
 
 
 @router.get("/api/preset_models")
 async def preset_models():
-    """返回精选的预设模型列表（来自 backend/model_manager/starter_models.py）。"""
+    """返回精选的预设模型组列表（每组含主模型与配套依赖）。"""
     from backend.model_manager import starter_models
 
     # 团队预制的 Flux 模型下载包（含配图），固定置于列表首位
-    flux_preset = {
-        "id": "001-flux-preset",
-        "name": "Flux Model Preset",
-        "base": "flux",
-        "type": "main",
-        "source": "InvokeAI/flux_schnell_quantized",
-        "description": "FLUX Schnell (Quantized) · clip-vit-large-patch14 · t5_bnb_int8_quantized_encoder · Flux Vae",
-        "size": "FLUX Schnell (Quantized) · clip-vit-large-patch14 · t5_bnb_int8_quantized_encoder · Flux Vae",
-        "imageUrl": FLUX_PRESET_IMAGE_URL,
-    }
-    items = [flux_preset]
+    flux_group = _starter_to_preset_group(starter_models.flux_schnell_quantized)
+    flux_group["id"] = "001-flux-preset"
+    flux_group["name"] = "Flux Model Preset"
+    flux_group["imageUrl"] = FLUX_PRESET_IMAGE_URL
+    items = [flux_group]
 
     preset_names = [
         "cyberrealistic_sd1",
@@ -179,7 +193,7 @@ async def preset_models():
     for name in preset_names:
         model = getattr(starter_models, name, None)
         if model is not None:
-            items.append(_preset_to_dict(model))
+            items.append(_starter_to_preset_group(model))
     return {"items": items}
 
 
@@ -210,22 +224,36 @@ async def preset_download(
             finish_callback=websocket_service.send_finish,
         )
     else:
-        # HuggingFace 仓库 ID：hf_download 的回调约定是 (client_id, request_uuid, name, data)
+        # HuggingFace 来源：hf_download 的回调约定是 (client_id, request_uuid, name, data)
         def hf_callback(cid: str, rid: str, name: str, data: dict):
             websocket_service.send_callback(cid, rid, {name: data})
 
         def hf_finish(cid: str, rid: str):
             websocket_service.send_finish(cid, rid)
 
-        background_task = BackgroundTask(
-            model_service.hf_download,
-            repo_id=source,
-            local_dir=local_dir,
-            client_id=client_id,
-            request_uuid=request_uuid,
-            callback=hf_callback,
-            finish_callback=hf_finish,
-        )
+        if "::" in source:
+            # starter model 来源格式：repo::path —— 单文件下载
+            hf_repo, hf_path = source.split("::", 1)
+            background_task = BackgroundTask(
+                model_service.hf_file_download,
+                repo_id=hf_repo,
+                filename=hf_path,
+                local_dir=local_dir,
+                client_id=client_id,
+                request_uuid=request_uuid,
+                callback=hf_callback,
+                finish_callback=hf_finish,
+            )
+        else:
+            background_task = BackgroundTask(
+                model_service.hf_download,
+                repo_id=source,
+                local_dir=local_dir,
+                client_id=client_id,
+                request_uuid=request_uuid,
+                callback=hf_callback,
+                finish_callback=hf_finish,
+            )
 
     return JSONResponse(
         content=jsonable_encoder(

--- a/server/routes/model_routes.py
+++ b/server/routes/model_routes.py
@@ -124,6 +124,16 @@ async def hf_models(search: str = "", limit: int = 50):
         return JSONResponse({"error": f"HuggingFace API request failed: {e}"}, status_code=502)
 
 
+# 团队预制的 Flux 模型下载包配图（来自原 PresetModels 设计）
+FLUX_PRESET_IMAGE_URL = (
+    "https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/f905bc28-9db6-4f83-85ae-93c94718881d/anim=false,width=450/NfX8MYg-_nTv_PpQBNJSr.jpeg"
+)
+
+PRESET_IMAGE_URLS = {
+    "FLUX Schnell (Quantized)": FLUX_PRESET_IMAGE_URL,
+}
+
+
 def _preset_to_dict(model) -> dict:
     base = getattr(model, "base", "")
     model_type = getattr(model, "type", "")
@@ -135,7 +145,7 @@ def _preset_to_dict(model) -> dict:
         "source": model.source,
         "description": model.description,
         "size": model.description,
-        "imageUrl": "",
+        "imageUrl": PRESET_IMAGE_URLS.get(model.name, ""),
     }
 
 
@@ -144,6 +154,19 @@ async def preset_models():
     """返回精选的预设模型列表（来自 backend/model_manager/starter_models.py）。"""
     from backend.model_manager import starter_models
 
+    # 团队预制的 Flux 模型下载包（含配图），固定置于列表首位
+    flux_preset = {
+        "id": "001-flux-preset",
+        "name": "Flux Model Preset",
+        "base": "flux",
+        "type": "main",
+        "source": "InvokeAI/flux_schnell_quantized",
+        "description": "FLUX Schnell (Quantized) · clip-vit-large-patch14 · t5_bnb_int8_quantized_encoder · Flux Vae",
+        "size": "FLUX Schnell (Quantized) · clip-vit-large-patch14 · t5_bnb_int8_quantized_encoder · Flux Vae",
+        "imageUrl": FLUX_PRESET_IMAGE_URL,
+    }
+    items = [flux_preset]
+
     preset_names = [
         "cyberrealistic_sd1",
         "rev_animated_sd1",
@@ -151,10 +174,8 @@ async def preset_models():
         "deliberate_sd1",
         "juggernaut_sdxl",
         "dreamshaper_sdxl",
-        "flux_schnell_quantized",
         "flux_dev_quantized",
     ]
-    items = []
     for name in preset_names:
         model = getattr(starter_models, name, None)
         if model is not None:

--- a/server/routes/task_routes.py
+++ b/server/routes/task_routes.py
@@ -125,14 +125,27 @@ async def _start_download(
             finish_callback=finish_callback,
         )
     elif repo_id:
-        await model_service.hf_download(
-            repo_id=repo_id,
-            local_dir=local_dir,
-            client_id="task",
-            request_uuid=request_uuid,
-            callback=hf_progress_callback,
-            finish_callback=finish_callback,
-        )
+        if "::" in repo_id:
+            # starter model 来源格式：repo::path —— 拆分为仓库与单文件下载
+            hf_repo, hf_path = repo_id.split("::", 1)
+            await model_service.hf_file_download(
+                repo_id=hf_repo,
+                filename=hf_path,
+                local_dir=local_dir,
+                client_id="task",
+                request_uuid=request_uuid,
+                callback=hf_progress_callback,
+                finish_callback=finish_callback,
+            )
+        else:
+            await model_service.hf_download(
+                repo_id=repo_id,
+                local_dir=local_dir,
+                client_id="task",
+                request_uuid=request_uuid,
+                callback=hf_progress_callback,
+                finish_callback=finish_callback,
+            )
     else:
         task_service.update(record_id, status="failed", error="url 或 repo_id 必须提供其一")
     return request_uuid


### PR DESCRIPTION
恢复团队预制的「Flux Model Preset」：/api/preset_models 首位固定返回该预制组（原配图），组内包含主模型 + t5/clip/vae 全套依赖；其余预设也按组返回成员并支持整套下载（新增 repo::path 单文件下载支持）。desktop build 与接口验证通过。