### PR TITLE
feat: 新增 code-editor-ui 代码编辑器视图与视图切换

### DIFF
--- a/frontend/functional_ui/package.json
+++ b/frontend/functional_ui/package.json
@@ -13,6 +13,7 @@
     "@blueprintjs/select": "^5.3.7",
     "@blueprintjs/table": "^5.3.1",
     "i18next": "^25.1.2",
+    "monaco-editor": "^0.52.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^15.5.1",

--- a/frontend/functional_ui/src/ui/UIProvider.ts
+++ b/frontend/functional_ui/src/ui/UIProvider.ts
@@ -3,6 +3,7 @@ import { ImagePreviewProvider } from "./preview/ImagePreview";
 import { ProjectSettingsProvider } from './settings/ProjectSettings';
 import { WorkflowUIProvider } from "./workflow/WorkflowUI";
 import { ModelManagerUIProvider } from "./models/ModelManager";
+import { CodeEditorUIProvider } from "./code_editor/CodeEditor";
 export interface UIProvider {
     getName(): string;
     getUI(path: string): JSX.Element;
@@ -24,3 +25,4 @@ registerUIProvider(new ProjectSettingsProvider());
 registerUIProvider(new ImagePreviewProvider());
 registerUIProvider(new WorkflowUIProvider());
 registerUIProvider(new ModelManagerUIProvider());
+registerUIProvider(new CodeEditorUIProvider());

--- a/frontend/functional_ui/src/ui/code_editor/CodeEditor.css
+++ b/frontend/functional_ui/src/ui/code_editor/CodeEditor.css
@@ -1,0 +1,59 @@
+.code-editor-root {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    padding: 16px;
+    box-sizing: border-box;
+    gap: 10px;
+}
+
+.code-editor-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.code-editor-header-info h1 {
+    margin: 0;
+    font-size: 24px;
+}
+
+.code-editor-header-info p {
+    margin: 4px 0 0;
+    color: var(--ssui-fg-muted);
+    word-break: break-all;
+}
+
+.code-editor-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.code-editor-status {
+    min-height: 18px;
+    font-size: 13px;
+}
+
+.code-editor-status-muted {
+    color: var(--ssui-fg-muted);
+}
+
+.code-editor-status-error {
+    color: var(--ssui-danger);
+}
+
+.code-editor-status-ok {
+    color: var(--ssui-primary);
+}
+
+.code-editor-container {
+    flex: 1;
+    min-height: 0;
+    border: 1px solid var(--ssui-border);
+    border-radius: 6px;
+    overflow: hidden;
+}

--- a/frontend/functional_ui/src/ui/code_editor/CodeEditor.tsx
+++ b/frontend/functional_ui/src/ui/code_editor/CodeEditor.tsx
@@ -1,0 +1,227 @@
+import React, { Component } from "react";
+import * as monaco from "monaco-editor";
+import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+import { Button, Intent } from "@blueprintjs/core";
+import { ViewSwitcher } from "../common/ViewSwitcher";
+import type { UIProvider } from "../UIProvider";
+import "./CodeEditor.css";
+
+// 使用本地打包的 Monaco worker，避免从 CDN 加载（桌面端离线可用）
+(self as any).MonacoEnvironment = {
+    getWorker: () => new EditorWorker(),
+};
+
+interface CodeEditorProps {
+    path: string;
+}
+
+interface CodeEditorState {
+    loading: boolean;
+    loadError: Error | null;
+    dirty: boolean;
+    saving: boolean;
+    saveError: Error | null;
+    savedAt: Date | null;
+}
+
+function currentMonacoTheme(): string {
+    return document.documentElement.dataset.theme === "dark" ? "vs-dark" : "vs";
+}
+
+export class CodeEditor extends Component<CodeEditorProps, CodeEditorState> {
+    private containerRef: React.RefObject<HTMLDivElement>;
+    private editor: monaco.editor.IStandaloneCodeEditor | null = null;
+    private lastSavedContent = "";
+    private themeObserver: MutationObserver | null = null;
+
+    constructor(props: CodeEditorProps) {
+        super(props);
+        this.containerRef = React.createRef<HTMLDivElement>();
+        this.state = {
+            loading: true,
+            loadError: null,
+            dirty: false,
+            saving: false,
+            saveError: null,
+            savedAt: null,
+        };
+    }
+
+    componentDidMount() {
+        this.createEditor();
+        this.loadContent();
+        this.watchTheme();
+        window.addEventListener("keydown", this.handleKeyDown);
+    }
+
+    componentWillUnmount() {
+        window.removeEventListener("keydown", this.handleKeyDown);
+        this.themeObserver?.disconnect();
+        this.editor?.dispose();
+        this.editor = null;
+    }
+
+    createEditor = (): void => {
+        if (!this.containerRef.current) {
+            return;
+        }
+        this.editor = monaco.editor.create(this.containerRef.current, {
+            value: "",
+            language: "python",
+            theme: currentMonacoTheme(),
+            automaticLayout: true,
+            fontSize: 14,
+            tabSize: 4,
+            insertSpaces: true,
+            minimap: { enabled: true },
+            scrollBeyondLastLine: false,
+            wordWrap: "off",
+            renderWhitespace: "selection",
+            scrollbar: {
+                verticalScrollbarSize: 10,
+                horizontalScrollbarSize: 10,
+            },
+        });
+        this.editor.onDidChangeModelContent(() => {
+            const value = this.editor?.getValue() ?? "";
+            this.setState({ dirty: value !== this.lastSavedContent });
+        });
+    };
+
+    watchTheme = (): void => {
+        this.themeObserver = new MutationObserver(() => {
+            monaco.editor.setTheme(currentMonacoTheme());
+        });
+        this.themeObserver.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ["data-theme"],
+        });
+    };
+
+    loadContent = async (): Promise<void> => {
+        try {
+            const response = await fetch("/file?" + new URLSearchParams({
+                path: this.props.path,
+            }));
+            if (!response.ok) {
+                throw new Error(`Failed to load file (${response.status})`);
+            }
+            const content = await response.text();
+            this.lastSavedContent = content;
+            this.editor?.setValue(content);
+            this.setState({ loading: false, loadError: null, dirty: false });
+        } catch (error) {
+            this.setState({
+                loading: false,
+                loadError: error instanceof Error ? error : new Error("Unknown error"),
+            });
+        }
+    };
+
+    handleKeyDown = (event: KeyboardEvent): void => {
+        if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "s") {
+            event.preventDefault();
+            void this.handleSave();
+        }
+    };
+
+    handleSave = async (): Promise<void> => {
+        if (this.state.saving) {
+            return;
+        }
+        const content = this.editor?.getValue() ?? "";
+        this.setState({ saving: true, saveError: null });
+        try {
+            const response = await fetch("/files/upload_json", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    path: this.props.path,
+                    content,
+                }),
+            });
+            const data = await response.json().catch(() => null);
+            if (!response.ok || (data && data.error)) {
+                throw new Error((data && data.error) || `Save failed (${response.status})`);
+            }
+            this.lastSavedContent = content;
+            this.setState({ saving: false, dirty: false, savedAt: new Date() });
+        } catch (error) {
+            this.setState({
+                saving: false,
+                saveError: error instanceof Error ? error : new Error("Unknown error"),
+            });
+        }
+    };
+
+    renderStatus = (): React.ReactNode => {
+        const { loading, loadError, dirty, saving, saveError, savedAt } = this.state;
+        if (loading) {
+            return <span className="code-editor-status-muted">Loading...</span>;
+        }
+        if (loadError) {
+            return <span className="code-editor-status-error">Error: {loadError.message}</span>;
+        }
+        if (saving) {
+            return <span className="code-editor-status-muted">Saving...</span>;
+        }
+        if (saveError) {
+            return <span className="code-editor-status-error">Save failed: {saveError.message}</span>;
+        }
+        if (dirty) {
+            return <span className="code-editor-status-muted">Unsaved changes</span>;
+        }
+        if (savedAt) {
+            return <span className="code-editor-status-ok">Saved at {savedAt.toLocaleTimeString()}</span>;
+        }
+        return <span className="code-editor-status-ok">Ready</span>;
+    };
+
+    render(): JSX.Element {
+        const { path } = this.props;
+        const { saving, loading, loadError } = this.state;
+
+        return (
+            <div className="code-editor-root">
+                <div className="code-editor-header">
+                    <div className="code-editor-header-info">
+                        <h1>Code Editor</h1>
+                        <p>Path: {path}</p>
+                    </div>
+                    <div className="code-editor-header-actions">
+                        <ViewSwitcher path={path} currentView="code_editor" />
+                        <Button
+                            intent={Intent.PRIMARY}
+                            icon="floppy-disk"
+                            loading={saving}
+                            disabled={loading || !!loadError}
+                            onClick={() => void this.handleSave()}
+                        >
+                            Save
+                        </Button>
+                    </div>
+                </div>
+                <div className="code-editor-status">{this.renderStatus()}</div>
+                <div className="code-editor-container" ref={this.containerRef} />
+            </div>
+        );
+    }
+}
+
+const CodeEditorView: React.FC<CodeEditorProps> = ({ path }) => {
+    return <CodeEditor path={path} />;
+};
+
+export class CodeEditorUIProvider implements UIProvider {
+    getName(): string {
+        return "code_editor";
+    }
+
+    getUI(path: string): JSX.Element {
+        return <CodeEditorView path={path} />;
+    }
+}
+
+export default CodeEditor;

--- a/frontend/functional_ui/src/ui/common/ViewSwitcher.css
+++ b/frontend/functional_ui/src/ui/common/ViewSwitcher.css
@@ -1,0 +1,13 @@
+.view-switcher {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px;
+    background: var(--ssui-card-bg);
+    border: 1px solid var(--ssui-border);
+    border-radius: 6px;
+}
+
+.view-switcher-button {
+    white-space: nowrap;
+}

--- a/frontend/functional_ui/src/ui/common/ViewSwitcher.tsx
+++ b/frontend/functional_ui/src/ui/common/ViewSwitcher.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { Button, IconName } from "@blueprintjs/core";
+import "./ViewSwitcher.css";
+
+export interface ViewOption {
+    view: string;
+    label: string;
+    icon: IconName;
+}
+
+/**
+ * 每种文件类型可用的视图（按顺序展示，当前视图高亮，点击可切换）。
+ * - .py：Functional UI（函数调用）↔ Code Editor（代码编辑）
+ * - .flow：Flow（流程图）↔ Functional UI
+ */
+const VIEW_OPTIONS: Record<string, ViewOption[]> = {
+    py: [
+        { view: "functional", label: "Functional UI", icon: "function" },
+        { view: "code_editor", label: "Code Editor", icon: "code" },
+    ],
+    flow: [
+        { view: "workflow", label: "Flow", icon: "graph" },
+        { view: "functional", label: "Functional UI", icon: "function" },
+    ],
+};
+
+interface ViewSwitcherProps {
+    path: string;
+    currentView: string;
+}
+
+function getExtension(path: string): string {
+    const basename = path.split(/[\\/]/).pop() ?? "";
+    const match = basename.match(/\.([^.]+)$/);
+    return match ? match[1].toLowerCase() : "";
+}
+
+function switchToView(path: string, view: string): void {
+    const base = window.location.origin + window.location.pathname;
+    window.location.href = `${base}?view=${view}&path=${encodeURIComponent(path)}`;
+}
+
+export const ViewSwitcher: React.FC<ViewSwitcherProps> = ({ path, currentView }) => {
+    const options = VIEW_OPTIONS[getExtension(path)];
+    if (!options) {
+        return null;
+    }
+
+    return (
+        <div className="view-switcher">
+            {options.map(option => (
+                <Button
+                    key={option.view}
+                    className="view-switcher-button"
+                    icon={option.icon}
+                    active={option.view === currentView}
+                    onClick={() => {
+                        if (option.view !== currentView) {
+                            switchToView(path, option.view);
+                        }
+                    }}
+                >
+                    {option.label}
+                </Button>
+            ))}
+        </div>
+    );
+};
+
+export default ViewSwitcher;

--- a/frontend/functional_ui/src/ui/functional/FunctionalUI.css
+++ b/frontend/functional_ui/src/ui/functional/FunctionalUI.css
@@ -4,6 +4,15 @@
     padding-right: 30px;
 }
 
+.functional-ui-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+    padding-top: 10px;
+}
+
 .functional-ui-container {
     margin-top: 20px;
     display: flex;

--- a/frontend/functional_ui/src/ui/functional/FunctionalUI.tsx
+++ b/frontend/functional_ui/src/ui/functional/FunctionalUI.tsx
@@ -6,6 +6,7 @@ import { ComponentTabRef } from "ssui_components";
 import { DetailsPanel } from "./Details";
 import { registerUIProvider, UIProvider } from '../UIProvider';
 import { useConfig } from '../../config';
+import { ViewSwitcher } from "../common/ViewSwitcher";
 import './FunctionalUI.css';
 import "normalize.css";
 import "@blueprintjs/core/lib/css/blueprint.css";
@@ -256,7 +257,15 @@ export class FunctionalUI extends Component<FunctionalUIProps, FunctionalUIState
         const { selectedFunc, isOpen } = this.state;
         const { path } = this.props;
 
-        const selected = selectedFunc?.name ?? Object.keys(meta)[0];
+        const keys = Object.keys(meta).filter(key => key !== "error");
+        if (keys.length === 0) {
+            const message = typeof meta["error"] === "string"
+                ? meta["error"]
+                : "该文件不是可用的 Python 脚本";
+            return <p>Error: {message}</p>;
+        }
+
+        const selected = selectedFunc?.name ?? keys[0];
 
         return (
             <div>
@@ -290,8 +299,13 @@ export class FunctionalUI extends Component<FunctionalUIProps, FunctionalUIState
 
         return (
             <div className='functional-ui-root'>
-                <h1>Functional UI</h1>
-                <p>Path: {path}</p>
+                <div className="functional-ui-header">
+                    <div>
+                        <h1>Functional UI</h1>
+                        <p>Path: {path}</p>
+                    </div>
+                    <ViewSwitcher path={path} currentView="functional" />
+                </div>
 
                 {loading ? (
                     <p>Loading...</p>

--- a/frontend/functional_ui/src/ui/workflow/WorkflowUI.tsx
+++ b/frontend/functional_ui/src/ui/workflow/WorkflowUI.tsx
@@ -1,5 +1,6 @@
 import { UIProvider } from "../UIProvider";
 import { Workflow } from "ssui_components";
+import { ViewSwitcher } from "../common/ViewSwitcher";
 
 interface WorkflowUIProps {
     path: string;
@@ -8,7 +9,19 @@ interface WorkflowUIProps {
 const WorkflowUI: React.FC<WorkflowUIProps> = ({ path }) => {
     
     return (
-        <Workflow path={path} />
+        <div style={{ position: "relative" }}>
+            <Workflow path={path} />
+            <div
+                style={{
+                    position: "absolute",
+                    top: 12,
+                    right: 12,
+                    zIndex: 200,
+                }}
+            >
+                <ViewSwitcher path={path} currentView="workflow" />
+            </div>
+        </div>
     );
 };
 

--- a/server/app.py
+++ b/server/app.py
@@ -120,6 +120,9 @@ def create_app(
         "FunctionalUI", ".py", "/functional_ui/?path="
     )
     FileOpenerManager.instance().register_opener(
+        "CodeEditorUI", ".py", "/functional_ui/?view=code_editor&path="
+    )
+    FileOpenerManager.instance().register_opener(
         "WorkflowUI", ".flow", "/functional_ui/?view=workflow&path="
     )
     FileOpenerManager.instance().register_opener(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4854,6 +4854,11 @@ mocha@^10.2.0:
     yargs-parser "^20.2.9"
     yargs-unparser "^2.0.0"
 
+monaco-editor@^0.52.2:
+  version "0.52.2"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.52.2.tgz#53c75a6fcc6802684e99fd1b2700299857002205"
+  integrity sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==
+
 ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"


### PR DESCRIPTION
## 概述

为 Python 脚本新增一种查看/编辑方式：基于 Monaco（VS Code 的编辑器库）的 code-editor-ui，并支持在视图间一键切换。

## 变更内容

- **Code Editor 视图**（\iew=code_editor\）：
  - 使用 \monaco-editor\，Python 语法高亮（Monaco 内置 Monarch tokenizer）
  - 本地打包 worker，离线可用，不依赖 CDN
  - 支持随时编辑与保存（\/files/upload_json\），Ctrl/Cmd+S 快捷保存
  - 跟随应用深浅色主题
- **视图切换器**（ViewSwitcher）：
  - \.py\：Functional UI ↔ Code Editor
  - \.flow\：Flow ↔ Functional UI
- **服务端**：为 \.py\ 注册 \CodeEditorUI\ opener（默认打开方式仍为 Functional UI）
- Functional UI 对非 Python 文件（如 .flow）做容错，显示友好错误提示而不是崩溃

## 验证

- \ssui_components\、\unctional_ui\ 的 \yarn build\（tsc && vite build）通过
- 本地演示服务 + headless Edge 实测四个视图渲染正常，保存链路往返验证通过

## 说明

- \.flow\ 切到 Functional UI 时，由于 Functional UI 解析的是 Python \@workflow\ 函数，会显示解析错误提示（切换器仍可切回 Flow）
- 新增依赖 \monaco-editor@^0.52.2\（已更新 yarn.lock）