### PR TITLE
feat(model): 预设模型组递归收集依赖并支持 repo::path 整套下载

### DIFF
--- a/server/model_service.py
+++ b/server/model_service.py
@@ -310,6 +310,13 @@ class ModelService:
         """下载 HuggingFace 仓库中的单个文件（处理 starter model 的 repo::path 来源）。"""
         loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
 
+        def safe_call_soon_threadsafe(fn, *args):
+            try:
+                loop.call_soon_threadsafe(fn, *args)
+            except RuntimeError:
+                # 事件循环已关闭（如测试环境或服务退出中），忽略进度上报
+                pass
+
         def download_thread():
             from huggingface_hub import hf_hub_download
             from tqdm.auto import tqdm
@@ -322,7 +329,7 @@ class ModelService:
 
                 def update(self, n=1):
                     super().update(n)
-                    loop.call_soon_threadsafe(
+                    safe_call_soon_threadsafe(
                         callback,
                         self.client_id,
                         self.request_uuid,
@@ -338,7 +345,7 @@ class ModelService:
 
                 def close(self):
                     super().close()
-                    loop.call_soon_threadsafe(
+                    safe_call_soon_threadsafe(
                         finish_callback,
                         self.client_id,
                         self.request_uuid,

--- a/server/routes/model_routes.py
+++ b/server/routes/model_routes.py
@@ -134,15 +134,33 @@ PRESET_IMAGE_URLS = {
 }
 
 
+def _collect_starter_members(model) -> list:
+    """递归收集模型及其所有依赖（含依赖的依赖），按 source 去重。"""
+    seen: set = set()
+    members: list = []
+
+    def visit(current):
+        source = getattr(current, "source", None)
+        if source in seen:
+            return
+        seen.add(source)
+        members.append(current)
+        for dep in list(getattr(current, "dependencies", None) or []):
+            visit(dep)
+
+    visit(model)
+    return members
+
+
 def _starter_to_preset_group(model) -> dict:
-    """把一个 starter model（含依赖）展开为一组预设模型。
+    """把一个 starter model（含全部依赖）展开为一组预设模型。
 
     模型组 = 主模型 + 其依赖的辅助模型（如 Flux 的 CLIP/T5/VAE），
     一组下载完即可直接出图。
     """
     base = getattr(model, "base", "")
     model_type = getattr(model, "type", "")
-    members = [model] + list(getattr(model, "dependencies", None) or [])
+    members = _collect_starter_members(model)
     member_items = []
     for member in members:
         m_base = getattr(member, "base", "")


### PR DESCRIPTION
预设模型组现在递归收集主模型及其全部依赖（含依赖的依赖，按 source 去重），确保每组都包含完整配套模型一并下载；hf_file_download 增加事件循环关闭防御。已用真实服务器端到端验证 repo::path 单文件下载成功、任务进度正确。