### PR TITLE
feat: ControlNet support for SD1.5 / SDXL / Flux (backend + UI)

### DIFF
--- a/examples/basic/workflow-flux.py
+++ b/examples/basic/workflow-flux.py
@@ -1,5 +1,5 @@
 from ssui import workflow, Prompt, Image, Noise
-from ssui_image.Flux import FluxModel, FluxClip, FluxLatent, FluxLora, FluxDenoise, FluxLatentDecode,FluxMergeLora
+from ssui_image.Flux import FluxModel, FluxClip, FluxLatent, FluxLora, FluxControlNet, FluxDenoise, FluxLatentDecode,FluxMergeLora
 from ssui.config import SSUIConfig
 from typing import List, Tuple
 
@@ -10,6 +10,14 @@ def txt2img(model: FluxModel, positive: Prompt, negative: Prompt) -> Image:
     positive, negative = FluxClip(config("Prompt To Condition"), model, positive, negative)
     latent = FluxLatent(config("Create Empty Latent"))
     latent = FluxDenoise(config("Denoise"), model, latent, positive, negative)
+    return FluxLatentDecode(config("Latent to Image"), model, latent)
+
+
+@workflow
+def txt2imgWithControlNet(model: FluxModel, control: FluxControlNet, positive: Prompt, negative: Prompt) -> Image:
+    positive, negative = FluxClip(config("Prompt To Condition"), model, positive, negative)
+    latent = FluxLatent(config("Create Empty Latent"))
+    latent = FluxDenoise(config("Denoise"), model, latent, positive, negative, control)
     return FluxLatentDecode(config("Latent to Image"), model, latent)
 
 

--- a/examples/basic/workflow-sd1.py
+++ b/examples/basic/workflow-sd1.py
@@ -1,6 +1,6 @@
 
 from ssui import workflow, Prompt, Image, Noise
-from ssui_image.SD1 import SD1Model, SD1Clip, SD1Latent, SD1Lora, SD1Denoise, SD1LatentDecode,SD1MergeLora, SD1IPAdapter
+from ssui_image.SD1 import SD1Model, SD1Clip, SD1Latent, SD1Lora, SD1ControlNet, SD1Denoise, SD1LatentDecode,SD1MergeLora, SD1IPAdapter
 from ssui.config import SSUIConfig
 from typing import List, Tuple
 
@@ -11,6 +11,14 @@ def txt2img(model: SD1Model, positive: Prompt, negative: Prompt) -> Image:
     positive, negative = SD1Clip(config("Prompt To Condition"), model, positive, negative)
     latent = SD1Latent(config("Create Empty Latent"))
     latent = SD1Denoise(config("Denoise"), model, latent, positive, negative)
+    return SD1LatentDecode(config("Latent to Image"), model, latent)
+
+
+@workflow
+def txt2imgWithControlNet(model: SD1Model, control: SD1ControlNet, positive: Prompt, negative: Prompt) -> Image:
+    positive, negative = SD1Clip(config("Prompt To Condition"), model, positive, negative)
+    latent = SD1Latent(config("Create Empty Latent"))
+    latent = SD1Denoise(config("Denoise"), model, latent, positive, negative, control)
     return SD1LatentDecode(config("Latent to Image"), model, latent)
 
 

--- a/examples/basic/workflow-sdxl.py
+++ b/examples/basic/workflow-sdxl.py
@@ -1,5 +1,5 @@
 from ssui import workflow, Prompt, Image, Noise
-from ssui_image.SDXL import SDXLModel, SDXLClip, SDXLLatent, SDXLLora, SDXLDenoise, SDXLLatentDecode,SDXLMergeLora
+from ssui_image.SDXL import SDXLModel, SDXLClip, SDXLLatent, SDXLLora, SDXLControlNet, SDXLDenoise, SDXLLatentDecode,SDXLMergeLora
 from ssui.config import SSUIConfig
 from typing import List, Tuple
 
@@ -10,6 +10,14 @@ def txt2img(model: SDXLModel, positive: Prompt, negative: Prompt) -> Image:
     positive, negative = SDXLClip(config("Prompt To Condition"), model, positive, negative)
     latent = SDXLLatent(config("Create Empty Latent"))
     latent = SDXLDenoise(config("Denoise"), model, latent, positive, negative)
+    return SDXLLatentDecode(config("Latent to Image"), model, latent)
+
+
+@workflow
+def txt2imgWithControlNet(model: SDXLModel, control: SDXLControlNet, positive: Prompt, negative: Prompt) -> Image:
+    positive, negative = SDXLClip(config("Prompt To Condition"), model, positive, negative)
+    latent = SDXLLatent(config("Create Empty Latent"))
+    latent = SDXLDenoise(config("Denoise"), model, latent, positive, negative, control)
     return SDXLLatentDecode(config("Latent to Image"), model, latent)
 
 

--- a/extensions/Image/ssui_image/Flux.py
+++ b/extensions/Image/ssui_image/Flux.py
@@ -1,10 +1,17 @@
 from typing import Optional,List
 from pathlib import Path
 import torch
+import PIL
 
 from ssui.config import SSUIConfig
 from .api.conditioning import BasicConditioningInfo, create_flux_conditioning
-from .api.denoise import flux_decode_latents, flux_denoise_image, FLuxLatents
+from .api.denoise import (
+    ApplyRange,
+    flux_decode_latents,
+    flux_denoise_image,
+    FluxControlNet as FluxControlNetField,
+    FLuxLatents,
+)
 from .api.model import (
     ModelLoaderService,
     FluxModel as ApiFluxModel,
@@ -13,7 +20,10 @@ from .api.model import (
     VAEModel,
     load_flux_model,
     LoRAModel,
-    load_lora
+    load_lora,
+    ControlNetModel,
+    load_controlnet,
+    load_vae,
 )
 from ssui.base import Prompt, Image
 from ssui.annotation import param
@@ -131,6 +141,86 @@ class FluxLora:
 
         return fluxlora
 
+
+class FluxControlNet:
+    """FLUX ControlNet workflow node (XLabs / InstantX).
+
+    Pairs a FLUX ControlNet model file with a control image and tuning
+    parameters. InstantX union ControlNets additionally need a VAE to encode
+    the control image (pass ``vae_path``); XLabs ControlNets don't.
+    """
+
+    def __init__(
+        self,
+        path: str = "",
+        image_path: str = "",
+        controlnet: Optional[ControlNetModel] = None,
+        image: Optional[PIL.Image.Image] = None,
+        vae: Optional[VAEModel] = None,
+        vae_path: str = "",
+        weight: float = 1.0,
+        resize_mode: str = "just_resize",
+        instantx_control_mode: int = -1,
+        begin_step_percent: float = 0.0,
+        end_step_percent: float = 1.0,
+    ):
+        self.path = path
+        self.image_path = image_path
+        self.controlnet = controlnet
+        self.image = image
+        self.vae = vae
+        self.vae_path = vae_path
+        self.weight = weight
+        self.resize_mode = resize_mode
+        self.instantx_control_mode = instantx_control_mode
+        self.begin_step_percent = begin_step_percent
+        self.end_step_percent = end_step_percent
+
+    @staticmethod
+    def load(
+        path: str,
+        image_path: str,
+        vae_path: str = "",
+        weight: float = 1.0,
+        resize_mode: str = "just_resize",
+        instantx_control_mode: int = -1,
+        begin_step_percent: float = 0.0,
+        end_step_percent: float = 1.0,
+    ) -> "FluxControlNet":
+        controlnet = load_controlnet(getModelLoader(), Path(path))
+        image = PIL.Image.open(image_path).convert("RGB")
+        vae = load_vae(getModelLoader(), Path(vae_path)) if vae_path else None
+        return FluxControlNet(
+            path=path,
+            image_path=image_path,
+            controlnet=controlnet,
+            image=image,
+            vae=vae,
+            vae_path=vae_path,
+            weight=weight,
+            resize_mode=resize_mode,
+            instantx_control_mode=instantx_control_mode,
+            begin_step_percent=begin_step_percent,
+            end_step_percent=end_step_percent,
+        )
+
+    def to_api_field(self) -> FluxControlNetField:
+        if self.controlnet is None or self.image is None:
+            raise ValueError(
+                "FluxControlNet is not loaded; call FluxControlNet.load() first."
+            )
+        return FluxControlNetField(
+            image=self.image,
+            control_model=self.controlnet.controlnet,
+            control_weight=self.weight,
+            apply_range=ApplyRange(
+                begin_step_percent=self.begin_step_percent,
+                end_step_percent=self.end_step_percent,
+            ),
+            resize_mode=self.resize_mode,
+            instantx_control_mode=self.instantx_control_mode,
+        )
+
 @param(
     "steps",
     Slider(1, 100, 1, labels=[1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]),
@@ -150,6 +240,7 @@ def FluxDenoise(
     latent: FluxLatent,
     positive: FluxCondition,
     negative: FluxCondition,
+    control: Optional[FluxControlNet] = None,
 ):
     if config.is_prepare():
         return FluxLatent(config("DenoiseToLatents"))
@@ -180,6 +271,8 @@ def FluxDenoise(
         add_noise=config["add_noise"],
         denoising_start=config["denoising_start"],
         denoising_end=config["denoising_end"],
+        control=control.to_api_field() if control is not None else None,
+        controlnet_vae=control.vae if control is not None else None,
     )
     return FluxLatent(config("DenoiseToLatents"), tensor.tensor)
 

--- a/extensions/Image/ssui_image/SD1.py
+++ b/extensions/Image/ssui_image/SD1.py
@@ -1,8 +1,9 @@
 from typing import Optional,List
 from pathlib import Path
+import PIL
 from ssui.config import SSUIConfig
 from .api.conditioning import BasicConditioningInfo, create_conditioning
-from .api.denoise import decode_latents, denoise_image
+from .api.denoise import ApplyRange, ControlNet, decode_latents, denoise_image
 from .api.model import (
     ModelLoaderService,
     UNetModel,
@@ -10,7 +11,9 @@ from .api.model import (
     VAEModel,
     load_model,
     LoRAModel,
-    load_lora
+    load_lora,
+    ControlNetModel,
+    load_controlnet,
 )
 from ssui.base import Prompt, Image
 from ssui.annotation import param
@@ -114,6 +117,78 @@ class SD1Lora:
             sd1lora.append(SD1Lora(lora=lora_models,weight=lora_weights[i]))
 
         return sd1lora
+
+
+class SD1ControlNet:
+    """SD1.5 ControlNet workflow node.
+
+    Pair a ControlNet model file with a control image (e.g. a pose/canny/depth
+    map) and tuning parameters. ``load()`` is what the frontend invokes when a
+    ControlNet input is provided; the resulting node is passed to ``SD1Denoise``.
+    """
+
+    def __init__(
+        self,
+        path: str = "",
+        image_path: str = "",
+        controlnet: Optional[ControlNetModel] = None,
+        image: Optional[PIL.Image.Image] = None,
+        weight: float = 1.0,
+        control_mode: str = "balanced",
+        resize_mode: str = "just_resize",
+        begin_step_percent: float = 0.0,
+        end_step_percent: float = 1.0,
+    ):
+        self.path = path
+        self.image_path = image_path
+        self.controlnet = controlnet
+        self.image = image
+        self.weight = weight
+        self.control_mode = control_mode
+        self.resize_mode = resize_mode
+        self.begin_step_percent = begin_step_percent
+        self.end_step_percent = end_step_percent
+
+    @staticmethod
+    def load(
+        path: str,
+        image_path: str,
+        weight: float = 1.0,
+        control_mode: str = "balanced",
+        resize_mode: str = "just_resize",
+        begin_step_percent: float = 0.0,
+        end_step_percent: float = 1.0,
+    ) -> "SD1ControlNet":
+        controlnet = load_controlnet(getModelLoader(), Path(path))
+        image = PIL.Image.open(image_path).convert("RGB")
+        return SD1ControlNet(
+            path=path,
+            image_path=image_path,
+            controlnet=controlnet,
+            image=image,
+            weight=weight,
+            control_mode=control_mode,
+            resize_mode=resize_mode,
+            begin_step_percent=begin_step_percent,
+            end_step_percent=end_step_percent,
+        )
+
+    def to_api_field(self) -> ControlNet:
+        if self.controlnet is None or self.image is None:
+            raise ValueError(
+                "SD1ControlNet is not loaded; call SD1ControlNet.load() first."
+            )
+        return ControlNet(
+            image=self.image,
+            control_model=self.controlnet.controlnet,
+            control_weight=self.weight,
+            apply_range=ApplyRange(
+                begin_step_percent=self.begin_step_percent,
+                end_step_percent=self.end_step_percent,
+            ),
+            control_mode=self.control_mode,
+            resize_mode=self.resize_mode,
+        )
     
 def SD1MergeLora(
     config,
@@ -180,6 +255,7 @@ def SD1Denoise(
     latent: SD1Latent,
     positive: SD1Condition,
     negative: SD1Condition,
+    control: Optional[SD1ControlNet] = None,
 ):
     if config.is_prepare():
         return SD1Latent(config("Create Empty Latent"))
@@ -199,6 +275,7 @@ def SD1Denoise(
         scheduler_name=config["scheduler"],
         steps=config["steps"],
         cfg_scale=config["CFG"],
+        control=control.to_api_field() if control is not None else None,
     )
     return SD1Latent(config("Create Empty Latent"), tensor)
 

--- a/extensions/Image/ssui_image/SDXL.py
+++ b/extensions/Image/ssui_image/SDXL.py
@@ -1,10 +1,11 @@
 from typing import Optional,List
 from pathlib import Path
 import torch
+import PIL
 from backend.stable_diffusion.diffusion.conditioning_data import SDXLConditioningInfo
 from ssui.config import SSUIConfig
 from .api.conditioning import BasicConditioningInfo, create_sdxl_conditioning
-from .api.denoise import decode_latents, denoise_image
+from .api.denoise import ApplyRange, ControlNet, decode_latents, denoise_image
 from .api.model import (
     ModelLoaderService,
     UNetModel,
@@ -13,7 +14,9 @@ from .api.model import (
     load_model,
     load_sdxl_model,
     LoRAModel,
-    load_lora
+    load_lora,
+    ControlNetModel,
+    load_controlnet,
 )
 from ssui.base import Prompt, Image
 from ssui.annotation import param
@@ -120,6 +123,78 @@ class SDXLLora:
             sdxlLora.append(SDXLLora(lora=lora_models,weight=lora_weights[i]))
 
         return sdxlLora
+
+
+class SDXLControlNet:
+    """SDXL ControlNet workflow node.
+
+    Pairs an SDXL ControlNet model file with a control image and tuning
+    parameters. ``load()`` is invoked by the frontend; the resulting node is
+    passed to ``SDXLDenoise``.
+    """
+
+    def __init__(
+        self,
+        path: str = "",
+        image_path: str = "",
+        controlnet: Optional[ControlNetModel] = None,
+        image: Optional[PIL.Image.Image] = None,
+        weight: float = 1.0,
+        control_mode: str = "balanced",
+        resize_mode: str = "just_resize",
+        begin_step_percent: float = 0.0,
+        end_step_percent: float = 1.0,
+    ):
+        self.path = path
+        self.image_path = image_path
+        self.controlnet = controlnet
+        self.image = image
+        self.weight = weight
+        self.control_mode = control_mode
+        self.resize_mode = resize_mode
+        self.begin_step_percent = begin_step_percent
+        self.end_step_percent = end_step_percent
+
+    @staticmethod
+    def load(
+        path: str,
+        image_path: str,
+        weight: float = 1.0,
+        control_mode: str = "balanced",
+        resize_mode: str = "just_resize",
+        begin_step_percent: float = 0.0,
+        end_step_percent: float = 1.0,
+    ) -> "SDXLControlNet":
+        controlnet = load_controlnet(getModelLoader(), Path(path))
+        image = PIL.Image.open(image_path).convert("RGB")
+        return SDXLControlNet(
+            path=path,
+            image_path=image_path,
+            controlnet=controlnet,
+            image=image,
+            weight=weight,
+            control_mode=control_mode,
+            resize_mode=resize_mode,
+            begin_step_percent=begin_step_percent,
+            end_step_percent=end_step_percent,
+        )
+
+    def to_api_field(self) -> ControlNet:
+        if self.controlnet is None or self.image is None:
+            raise ValueError(
+                "SDXLControlNet is not loaded; call SDXLControlNet.load() first."
+            )
+        return ControlNet(
+            image=self.image,
+            control_model=self.controlnet.controlnet,
+            control_weight=self.weight,
+            apply_range=ApplyRange(
+                begin_step_percent=self.begin_step_percent,
+                end_step_percent=self.end_step_percent,
+            ),
+            control_mode=self.control_mode,
+            resize_mode=self.resize_mode,
+        )
     
 @param(
     "steps",
@@ -169,6 +244,7 @@ def SDXLDenoise(
     latent: SDXLLatent,
     positive: SDXLCondition,
     negative: SDXLCondition,
+    control: Optional[SDXLControlNet] = None,
 ):
     if config.is_prepare():
         return SDXLLatent(config("DenoiseToLatents"))
@@ -188,6 +264,7 @@ def SDXLDenoise(
         scheduler_name=config["scheduler"],
         steps=config["steps"],
         cfg_scale=config["CFG"],
+        control=control.to_api_field() if control is not None else None,
     )
     return SDXLLatent(config("DenoiseToLatents"), tensor)
 

--- a/extensions/Image/ssui_image/api/model.py
+++ b/extensions/Image/ssui_image/api/model.py
@@ -164,6 +164,13 @@ class ControlLoRAModel(LoRAModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
+class ControlNetModel(BaseModel):
+    """A loaded ControlNet model (SD1.5 / SD2 / SDXL / Flux)."""
+
+    controlnet: "LoadedModel" = Field(description="The controlnet model", validate=False)
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
 class UNetModel(BaseModel):
     unet: "LoadedModel" = Field(description="The basic unet model", validate=False)
     scheduler: "LoadedModel" = Field(
@@ -402,3 +409,29 @@ def load_lora(
     lora_model = LoRAModel(lora=lora,weight=lora_weight)
   
     return lora_model
+
+
+def load_controlnet(
+    model_loader_service: ModelLoaderService,
+    controlnet_path: Path,
+) -> ControlNetModel:
+    """Load a ControlNet model (SD1.5 / SD2 / SDXL / Flux).
+
+    The model file is probed to determine its base model type and format, then
+    dispatched to the registered ControlNet loader for that family.
+    """
+    controlnet_config = ModelProbe.probe(Path(controlnet_path))
+    controlnet = _load_model_service(
+        model_loader_service, controlnet_config, None
+    )
+    return ControlNetModel(controlnet=controlnet)
+
+
+def load_vae(
+    model_loader_service: ModelLoaderService,
+    vae_path: Path,
+) -> VAEModel:
+    """Load a standalone VAE model (used e.g. by InstantX FLUX ControlNets)."""
+    vae_config = ModelProbe.probe(Path(vae_path))
+    vae = _load_model_service(model_loader_service, vae_config, SubModelType.VAE)
+    return VAEModel(vae=vae)

--- a/frontend/ssui_components/src/components/InternalComponents.ts
+++ b/frontend/ssui_components/src/components/InternalComponents.ts
@@ -2,6 +2,7 @@ import './Image/ImageUploader';
 import './Image/ImagePicker';
 import './Video/VideoUploader';
 import './Loader/SDLoader';
+import './Loader/ControlNetLoader';
 import './Base/ListContainer';
 import './Base/StringEditor';
 import './Base/PromptEditor';

--- a/frontend/ssui_components/src/components/Loader/ControlNetLoader.tsx
+++ b/frontend/ssui_components/src/components/Loader/ControlNetLoader.tsx
@@ -1,0 +1,250 @@
+import React, { Component } from 'react';
+import { registerComponent, ComponentRegister } from '../ComponentsManager';
+
+interface ControlNetModel {
+    name: string;
+    path: string;
+}
+
+interface ControlNetLoaderProps {
+    script_path: string;
+}
+
+interface ControlNetLoaderState {
+    filePath: string;
+    imagePath: string;
+    weight: number;
+    vaePath: string;
+    models: ControlNetModel[];
+    vaeModels: ControlNetModel[];
+    loading: boolean;
+    error: string | null;
+}
+
+/**
+ * 生成 ControlNet 模型加载器组件。
+ *
+ * 组件的 onExecute() 返回可供 ss_executor 执行的函数调用描述：
+ *   { 'function': 'ssui_image.SD1.SD1ControlNet.load', 'params': { path, image_path, weight } }
+ *
+ * @param baseType   模型基底类型（sd-1 / sdxl / flux），用于过滤已安装模型
+ * @param withVae    FLUX InstantX ControlNet 需要额外的 VAE（用于编码控制图）
+ * @param functionName 后端 ControlNet 节点的静态 load 方法
+ */
+function getControlNetLoader(
+    baseType: 'sd-1' | 'sdxl' | 'flux',
+    withVae: boolean,
+    functionName: string,
+) {
+    return class ControlNetModelLoader extends Component<
+        ControlNetLoaderProps,
+        ControlNetLoaderState
+    > {
+        state: ControlNetLoaderState = {
+            filePath: '',
+            imagePath: '',
+            weight: 1.0,
+            vaePath: '',
+            models: [],
+            vaeModels: [],
+            loading: false,
+            error: null,
+        };
+
+        componentDidMount() {
+            this.fetchModels();
+        }
+
+        async fetchModels() {
+            this.setState({ loading: true, error: null });
+            try {
+                const response = await fetch('/api/available_models');
+                if (!response.ok) {
+                    throw new Error('获取模型列表失败');
+                }
+                const allModels = await response.json();
+
+                // 已安装的 ControlNet 模型带 "controlnet" 标签（见 server/model_service.py）
+                const models = allModels.filter(
+                    (model: any) =>
+                        String(model.base_model).includes(baseType) &&
+                        (model.tags ?? []).includes('controlnet'),
+                );
+                const vaeModels = withVae
+                    ? allModels.filter(
+                          (model: any) =>
+                              String(model.base_model).includes(baseType) &&
+                              (model.tags ?? []).includes('vae'),
+                      )
+                    : [];
+
+                this.setState({ models, vaeModels, loading: false });
+            } catch (error) {
+                this.setState({
+                    loading: false,
+                    error:
+                        error instanceof Error
+                            ? error.message
+                            : '获取模型列表失败',
+                });
+            }
+        }
+
+        handleImageChange = async (
+            event: React.ChangeEvent<HTMLInputElement>,
+        ) => {
+            const file = event.target.files?.[0];
+            if (!file) return;
+
+            const formData = new FormData();
+            formData.append('file', file);
+            try {
+                const response = await fetch(
+                    `/files/upload?script_path=${this.props.script_path}`,
+                    { method: 'POST', body: formData },
+                );
+                const data = await response.json();
+                if (data.success) {
+                    this.setState({ imagePath: data.path });
+                }
+            } catch (error) {
+                console.error('上传控制图失败:', error);
+            }
+        };
+
+        onExecute() {
+            const params: any = {
+                path: this.state.filePath,
+                image_path: this.state.imagePath,
+                weight: this.state.weight,
+            };
+            if (withVae) {
+                params.vae_path = this.state.vaePath;
+            }
+            return { 'function': functionName, 'params': params };
+        }
+
+        renderModelSelect(
+            models: ControlNetModel[],
+            value: string,
+            placeholder: string,
+            onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void,
+        ) {
+            return (
+                <div style={{ marginBottom: '8px' }}>
+                    <select
+                        value={value}
+                        onChange={onChange}
+                        style={{ width: '100%' }}
+                    >
+                        <option value="">{placeholder}</option>
+                        {models.map((model, index) => (
+                            <option key={index} value={model.path}>
+                                {model.name}
+                            </option>
+                        ))}
+                    </select>
+                </div>
+            );
+        }
+
+        render() {
+            const { models, vaeModels, loading, error } = this.state;
+            if (loading) {
+                return <div>加载中...</div>;
+            }
+            if (error) {
+                return <div style={{ color: 'red' }}>{error}</div>;
+            }
+
+            return (
+                <div>
+                    {this.renderModelSelect(
+                        models,
+                        this.state.filePath,
+                        '选择 ControlNet 模型...',
+                        (event) =>
+                            this.setState({ filePath: event.target.value }),
+                    )}
+                    {withVae &&
+                        this.renderModelSelect(
+                            vaeModels,
+                            this.state.vaePath,
+                            '选择 ControlNet VAE（可选）...',
+                            (event) =>
+                                this.setState({ vaePath: event.target.value }),
+                        )}
+                    <div style={{ marginBottom: '8px' }}>
+                        <input
+                            type="file"
+                            accept="image/*"
+                            onChange={this.handleImageChange}
+                            style={{ width: '100%' }}
+                        />
+                    </div>
+                    {this.state.imagePath && (
+                        <div style={{ marginBottom: '8px' }}>
+                            <img
+                                src={'/file?path=' + this.state.imagePath}
+                                alt="control image preview"
+                                style={{ maxWidth: '100%', height: 'auto' }}
+                            />
+                        </div>
+                    )}
+                    <div style={{ marginBottom: '8px' }}>
+                        <label>
+                            权重: {this.state.weight.toFixed(2)}
+                            <input
+                                type="range"
+                                min="0"
+                                max="2"
+                                step="0.05"
+                                value={this.state.weight}
+                                onChange={(event) =>
+                                    this.setState({
+                                        weight: parseFloat(event.target.value),
+                                    })
+                                }
+                                style={{ width: '100%' }}
+                            />
+                        </label>
+                    </div>
+                </div>
+            );
+        }
+    };
+}
+
+// Register into the component manager
+[
+    {
+        'name': 'SD1ControlNetLoader',
+        'type': 'ssui_image.SD1.SD1ControlNet',
+        'port': 'input',
+        'component': getControlNetLoader(
+            'sd-1',
+            false,
+            'ssui_image.SD1.SD1ControlNet.load',
+        ),
+    } as ComponentRegister,
+    {
+        'name': 'SDXLControlNetLoader',
+        'type': 'ssui_image.SDXL.SDXLControlNet',
+        'port': 'input',
+        'component': getControlNetLoader(
+            'sdxl',
+            false,
+            'ssui_image.SDXL.SDXLControlNet.load',
+        ),
+    } as ComponentRegister,
+    {
+        'name': 'FluxControlNetLoader',
+        'type': 'ssui_image.Flux.FluxControlNet',
+        'port': 'input',
+        'component': getControlNetLoader(
+            'flux',
+            true,
+            'ssui_image.Flux.FluxControlNet.load',
+        ),
+    } as ComponentRegister,
+].forEach(registerComponent);

--- a/frontend/ssui_components/test/ControlNetLoader.test.ts
+++ b/frontend/ssui_components/test/ControlNetLoader.test.ts
@@ -1,0 +1,48 @@
+import { getComponentsByType } from '../src/components/ComponentsManager';
+
+// 触发 ControlNetLoader 模块内的组件注册
+import '../src/components/Loader/ControlNetLoader';
+
+describe('ControlNetLoader', () => {
+    it('registers loaders for SD1.5 / SDXL / FLUX ControlNet types', () => {
+        const sd1 = getComponentsByType('ssui_image.SD1.SD1ControlNet');
+        const sdxl = getComponentsByType('ssui_image.SDXL.SDXLControlNet');
+        const flux = getComponentsByType('ssui_image.Flux.FluxControlNet');
+
+        expect(sd1.some((c) => c.name === 'SD1ControlNetLoader')).toBe(true);
+        expect(sdxl.some((c) => c.name === 'SDXLControlNetLoader')).toBe(true);
+        expect(flux.some((c) => c.name === 'FluxControlNetLoader')).toBe(true);
+    });
+
+    it('emits a load() call description consumable by ss_executor', () => {
+        const registered = getComponentsByType(
+            'ssui_image.SD1.SD1ControlNet',
+        ).find((c) => c.name === 'SD1ControlNetLoader');
+        expect(registered).toBeDefined();
+
+        // 通过 createComponent 拿到一个实例，验证 onExecute 的输出结构
+        const element = registered!.createComponent(
+            { current: null } as never,
+            {
+                name: 'control',
+                type: 'ssui_image.SD1.SD1ControlNet',
+                port: 'input',
+                root_path: '',
+                script_path: 'examples/basic/workflow-sd1.py',
+            },
+        );
+
+        // createComponent 返回 React 元素；直接实例化组件类来验证 onExecute
+        const Cls = registered!.component as new (props: {
+            script_path: string;
+        }) => { onExecute(): any };
+        const instance = new Cls({ script_path: 'examples/basic/workflow-sd1.py' });
+        const result = instance.onExecute();
+
+        expect(result.function).toBe('ssui_image.SD1.SD1ControlNet.load');
+        expect(result.params).toHaveProperty('path');
+        expect(result.params).toHaveProperty('image_path');
+        expect(result.params).toHaveProperty('weight', 1.0);
+        expect(element).toBeDefined();
+    });
+});

--- a/server/model_service.py
+++ b/server/model_service.py
@@ -135,6 +135,8 @@ class ModelService:
         tags.append(model_config.base)
         if model_config.type == ModelType.LoRA:
             tags.append("lora")
+        elif model_config.type == ModelType.ControlNet:
+            tags.append("controlnet")
         elif model_config.type == ModelType.T5Encoder:
             tags.append("t5")
         elif model_config.type == ModelType.VAE:

--- a/tests/controlnet_test.py
+++ b/tests/controlnet_test.py
@@ -1,0 +1,392 @@
+"""ControlNet（SD1.5 / SDXL / FLUX）支持的后端测试。
+
+覆盖三类内容：
+1. ControlNet / FluxControlNet API 字段的校验规则；
+2. load_controlnet / load_vae 模型加载辅助函数；
+3. SD1 / SDXL / FLUX 工作流节点：ControlNet 节点加载、denoise 透传，
+   以及示例 workflow 脚本能注册 txt2imgWithControlNet 并完成 prepare pass。
+"""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from PIL import Image as PILImage
+
+from ssui.base import Prompt
+from ssui.config import SSUIConfig
+
+from tests.fakes.sd import (
+    FakeCondition,
+    FakeFluxModel,
+    FakeLatent,
+    FakeSD1Model,
+    FakeSDXLModel,
+    fake_clip,
+)
+
+
+def _loaded_model():
+    """构造一个满足 pydantic LoadedModel 校验的最小实例。"""
+    from backend.model_manager.load.load_base import LoadedModel
+
+    return LoadedModel(
+        config=None,
+        cache_record=MagicMock(),
+        cache=MagicMock(),
+    )
+
+
+def _make_control_image(path: str) -> str:
+    PILImage.new("RGB", (64, 64), (200, 120, 40)).save(path)
+    return path
+
+
+class TestControlNetFieldValidation(unittest.TestCase):
+    """ControlNet / FluxControlNet pydantic 字段的校验。"""
+
+    def test_apply_range_rejects_inverted_range(self):
+        from ssui_image.api.denoise import ApplyRange
+
+        with self.assertRaises(ValueError):
+            ApplyRange(begin_step_percent=0.8, end_step_percent=0.4)
+
+    def test_apply_range_accepts_valid_range(self):
+        from ssui_image.api.denoise import ApplyRange
+
+        r = ApplyRange(begin_step_percent=0.2, end_step_percent=0.9)
+        self.assertEqual(r.begin_step_percent, 0.2)
+        self.assertEqual(r.end_step_percent, 0.9)
+
+    def test_control_weight_range(self):
+        from ssui_image.api.denoise import ControlNet, FluxControlNet
+
+        base = {
+            "image": PILImage.new("RGB", (8, 8)),
+            "control_model": _loaded_model(),
+        }
+        for cls in (ControlNet, FluxControlNet):
+            with self.assertRaises(ValueError):
+                cls(**base, control_weight=3.0)
+            with self.assertRaises(ValueError):
+                cls(**base, control_weight=-2.0)
+            field = cls(**base, control_weight=1.5)
+            self.assertEqual(field.control_weight, 1.5)
+
+
+class TestLoadControlNetHelpers(unittest.TestCase):
+    """load_controlnet / load_vae 辅助函数。"""
+
+    @patch("ssui_image.api.model.ModelProbe")
+    @patch("ssui_image.api.model._load_model_service")
+    def test_load_controlnet(self, mock_load, mock_probe):
+        from ssui_image.api.model import (
+            ControlNetModel,
+            load_controlnet,
+        )
+
+        mock_probe.probe.return_value = MagicMock()
+        mock_load.return_value = _loaded_model()
+
+        result = load_controlnet(MagicMock(), "fake/controlnet.safetensors")
+
+        self.assertIsInstance(result, ControlNetModel)
+        mock_probe.probe.assert_called_once()
+        mock_load.assert_called_once()
+
+    @patch("ssui_image.api.model.ModelProbe")
+    @patch("ssui_image.api.model._load_model_service")
+    def test_load_vae(self, mock_load, mock_probe):
+        from ssui_image.api.model import VAEModel, load_vae
+
+        mock_probe.probe.return_value = MagicMock()
+        mock_load.return_value = _loaded_model()
+
+        result = load_vae(MagicMock(), "fake/vae.safetensors")
+
+        self.assertIsInstance(result, VAEModel)
+        mock_probe.probe.assert_called_once()
+        mock_load.assert_called_once()
+
+
+class TestSD1ControlNetWorkflow(unittest.TestCase):
+    """SD1.5 ControlNet 节点加载 + denoise 透传。"""
+
+    def setUp(self):
+        self.config = SSUIConfig()
+        self.positive = Prompt("a beautiful girl, masterpiece, best quality")
+        self.negative = Prompt("a bad image")
+
+    @patch("ssui_image.SD1.load_controlnet")
+    def test_node_load(self, mock_load_controlnet):
+        from ssui_image.SD1 import SD1ControlNet
+
+        mock_load_controlnet.return_value = MagicMock()
+        mock_load_controlnet.return_value.controlnet = _loaded_model()
+        with tempfile.TemporaryDirectory() as tmp:
+            image_path = _make_control_image(os.path.join(tmp, "pose.png"))
+            node = SD1ControlNet.load(
+                "fake/controlnet.safetensors",
+                image_path,
+                weight=0.7,
+                resize_mode="crop_resize",
+            )
+
+        self.assertEqual(node.path, "fake/controlnet.safetensors")
+        self.assertEqual(node.weight, 0.7)
+        self.assertEqual(node.resize_mode, "crop_resize")
+        self.assertEqual(node.image.size, (64, 64))
+        field = node.to_api_field()
+        self.assertEqual(field.control_weight, 0.7)
+        self.assertEqual(field.resize_mode, "crop_resize")
+        self.assertEqual(field.control_mode, "balanced")
+
+    def test_node_requires_load(self):
+        from ssui_image.SD1 import SD1ControlNet
+
+        with self.assertRaises(ValueError):
+            SD1ControlNet().to_api_field()
+
+    @patch("ssui_image.SD1.SD1Clip", fake_clip)
+    @patch("ssui_image.SD1.denoise_image", return_value=FakeLatent())
+    def test_denoise_passes_control_field(self, mock_denoise):
+        from ssui_image.SD1 import (
+            SD1Clip,
+            SD1ControlNet,
+            SD1Denoise,
+            SD1Latent,
+        )
+
+        control = SD1ControlNet(
+            path="fake/controlnet.safetensors",
+            image_path="",
+            controlnet=MagicMock(controlnet=_loaded_model()),
+            image=PILImage.new("RGB", (64, 64)),
+            weight=0.8,
+        )
+        positive, negative = SD1Clip(
+            self.config("Prompt To Condition"),
+            FakeSD1Model(),
+            self.positive,
+            self.negative,
+        )
+        latent = SD1Latent(self.config("Create Empty Latent"))
+        SD1Denoise(
+            self.config("Denoise"),
+            FakeSD1Model(),
+            latent,
+            positive,
+            negative,
+            control,
+        )
+
+        kwargs = mock_denoise.call_args.kwargs
+        field = kwargs["control"]
+        self.assertEqual(field.control_weight, 0.8)
+        self.assertEqual(field.image.size, (64, 64))
+
+    @patch("ssui_image.SD1.SD1Clip", fake_clip)
+    @patch("ssui_image.SD1.denoise_image", return_value=FakeLatent())
+    def test_denoise_without_control_passes_none(self, mock_denoise):
+        from ssui_image.SD1 import (
+            SD1Clip,
+            SD1Denoise,
+            SD1Latent,
+        )
+
+        positive, negative = SD1Clip(
+            self.config("Prompt To Condition"),
+            FakeSD1Model(),
+            self.positive,
+            self.negative,
+        )
+        latent = SD1Latent(self.config("Create Empty Latent"))
+        SD1Denoise(
+            self.config("Denoise"),
+            FakeSD1Model(),
+            latent,
+            positive,
+            negative,
+        )
+        self.assertIsNone(mock_denoise.call_args.kwargs["control"])
+
+
+class TestSDXLControlNetWorkflow(unittest.TestCase):
+    """SDXL ControlNet 节点加载 + denoise 透传。"""
+
+    def setUp(self):
+        self.config = SSUIConfig()
+        self.positive = Prompt("a beautiful girl in a red dress")
+        self.negative = Prompt("a bad image")
+
+    @patch("ssui_image.SDXL.load_controlnet")
+    def test_node_load(self, mock_load_controlnet):
+        from ssui_image.SDXL import SDXLControlNet
+
+        mock_load_controlnet.return_value = MagicMock(controlnet=_loaded_model())
+        with tempfile.TemporaryDirectory() as tmp:
+            image_path = _make_control_image(os.path.join(tmp, "depth.png"))
+            node = SDXLControlNet.load(
+                "fake/controlnet.safetensors",
+                image_path,
+                weight=0.9,
+                control_mode="more_control",
+            )
+
+        self.assertEqual(node.weight, 0.9)
+        self.assertEqual(node.control_mode, "more_control")
+        field = node.to_api_field()
+        self.assertEqual(field.control_mode, "more_control")
+
+    @patch("ssui_image.SDXL.SDXLClip", fake_clip)
+    @patch("ssui_image.SDXL.denoise_image", return_value=FakeLatent())
+    def test_denoise_passes_control_field(self, mock_denoise):
+        from ssui_image.SDXL import (
+            SDXLClip,
+            SDXLControlNet,
+            SDXLDenoise,
+            SDXLLatent,
+        )
+
+        control = SDXLControlNet(
+            path="fake/controlnet.safetensors",
+            image_path="",
+            controlnet=MagicMock(controlnet=_loaded_model()),
+            image=PILImage.new("RGB", (64, 64)),
+            weight=0.6,
+        )
+        positive, negative = SDXLClip(
+            self.config("Prompt To Condition"),
+            FakeSDXLModel(),
+            self.positive,
+            self.negative,
+        )
+        latent = SDXLLatent(self.config("Create Empty Latent"))
+        SDXLDenoise(
+            self.config("Denoise"),
+            FakeSDXLModel(),
+            latent,
+            positive,
+            negative,
+            control,
+        )
+
+        kwargs = mock_denoise.call_args.kwargs
+        field = kwargs["control"]
+        self.assertEqual(field.control_weight, 0.6)
+        self.assertEqual(field.image.size, (64, 64))
+
+
+class TestFluxControlNetWorkflow(unittest.TestCase):
+    """FLUX ControlNet 节点加载 + denoise 透传。"""
+
+    def setUp(self):
+        self.config = SSUIConfig()
+        self.positive = Prompt("a beautiful girl in a red dress")
+        self.negative = Prompt("a bad image")
+
+    @patch("ssui_image.Flux.load_controlnet")
+    @patch("ssui_image.Flux.load_vae")
+    def test_node_load(self, mock_load_vae, mock_load_controlnet):
+        from ssui_image.Flux import FluxControlNet
+
+        mock_load_controlnet.return_value = MagicMock(controlnet=_loaded_model())
+        mock_load_vae.return_value = MagicMock()
+        with tempfile.TemporaryDirectory() as tmp:
+            image_path = _make_control_image(os.path.join(tmp, "pose.png"))
+            node = FluxControlNet.load(
+                "fake/controlnet.safetensors",
+                image_path,
+                vae_path="fake/vae.safetensors",
+                weight=0.5,
+                instantx_control_mode=4,
+            )
+
+        self.assertEqual(node.weight, 0.5)
+        self.assertEqual(node.instantx_control_mode, 4)
+        self.assertEqual(node.vae_path, "fake/vae.safetensors")
+        mock_load_vae.assert_called_once()
+        field = node.to_api_field()
+        self.assertEqual(field.instantx_control_mode, 4)
+        self.assertEqual(field.resize_mode, "just_resize")
+
+    @patch("ssui_image.Flux.FluxClip", fake_clip)
+    @patch("ssui_image.Flux.flux_denoise_image", return_value=FakeLatent())
+    def test_denoise_passes_control_and_vae(self, mock_denoise):
+        from ssui_image.Flux import (
+            FluxClip,
+            FluxControlNet,
+            FluxDenoise,
+            FluxLatent,
+        )
+
+        vae = MagicMock()
+        control = FluxControlNet(
+            path="fake/controlnet.safetensors",
+            image_path="",
+            controlnet=MagicMock(controlnet=_loaded_model()),
+            image=PILImage.new("RGB", (64, 64)),
+            vae=vae,
+            weight=0.4,
+        )
+        positive, negative = FluxClip(
+            self.config("Prompt To Condition"),
+            FakeFluxModel(),
+            self.positive,
+            self.negative,
+        )
+        latent = FluxLatent(self.config("Create Empty Latent"))
+        FluxDenoise(
+            self.config("Denoise"),
+            FakeFluxModel(),
+            latent,
+            positive,
+            negative,
+            control,
+        )
+
+        kwargs = mock_denoise.call_args.kwargs
+        self.assertEqual(kwargs["control"].control_weight, 0.4)
+        self.assertIs(kwargs["controlnet_vae"], vae)
+
+
+class TestControlNetWorkflowScripts(unittest.TestCase):
+    """示例 workflow 脚本能注册 txt2imgWithControlNet 并完成 prepare pass。"""
+
+    def _prepare(self, script_name: str):
+        from ss_executor.loader import SSLoader
+
+        script = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "examples",
+            "basic",
+            script_name,
+        )
+        loader = SSLoader(use_sandbox=False)
+        loader.load(os.path.abspath(script))
+        loader.Execute()
+        return loader
+
+    def test_sd1_script(self):
+        loader = self._prepare("workflow-sd1.py")
+        names = [func.__name__ for func, _, _ in loader.callables]
+        self.assertIn("txt2imgWithControlNet", names)
+        config = loader.GetConfig("txt2imgWithControlNet")
+        self.assertIn("Denoise", config)
+        self.assertIn("Create Empty Latent", config)
+
+    def test_sdxl_script(self):
+        loader = self._prepare("workflow-sdxl.py")
+        names = [func.__name__ for func, _, _ in loader.callables]
+        self.assertIn("txt2imgWithControlNet", names)
+        config = loader.GetConfig("txt2imgWithControlNet")
+        self.assertIn("Denoise", config)
+
+    def test_flux_script(self):
+        loader = self._prepare("workflow-flux.py")
+        names = [func.__name__ for func, _, _ in loader.callables]
+        self.assertIn("txt2imgWithControlNet", names)
+        config = loader.GetConfig("txt2imgWithControlNet")
+        self.assertIn("Denoise", config)


### PR DESCRIPTION
## 概述

为 SD1.5 / SDXL / FLUX 三套模型补齐 ControlNet 的完整链路：Python 后端 workflow 节点、模型加载辅助函数，以及前端 UI 加载组件。

## 后端（Python）

- `extensions/Image/ssui_image/api/model.py`
  - 新增 `ControlNetModel` 包装与 `load_controlnet()`：自动探测模型类型/格式，分派到对应模型族的 ControlNet loader（SD1.5/SD2/SDXL/FLUX，checkpoint 与 diffusers 两种格式）
  - 新增 `load_vae()`：InstantX FLUX ControlNet 编码控制图所需的 VAE
- `extensions/Image/ssui_image/SD1.py` / `SDXL.py`
  - 新增 `SD1ControlNet` / `SDXLControlNet` 节点（模型 + 控制图 + 权重/模式/缩放/生效区间）
  - `SD1Denoise` / `SDXLDenoise` 增加 `control` 参数并透传至 denoise API
- `extensions/Image/ssui_image/Flux.py`
  - 新增 `FluxControlNet` 节点（支持 XLabs 与 InstantX，可选 `vae_path` 与 `instantx_control_mode`）
  - `FluxDenoise` 透传 `control` 与 `controlnet_vae`
- `server/model_service.py`：安装模型时为 ControlNet 增加 `controlnet` 标签，前端可按标签筛选
- 示例工作流（`examples/basic/workflow-sd1.py` / `workflow-sdxl.py` / `workflow-flux.py`）新增 `txt2imgWithControlNet`

## 前端

- `frontend/ssui_components/.../Loader/ControlNetLoader.tsx`：为 `ssui_image.SD1.SD1ControlNet` / `SDXL.SDXLControlNet` / `Flux.FluxControlNet` 注册输入组件，含模型下拉、控制图上传与预览、权重滑杆；FLUX 额外提供可选 VAE 选择
- Canvas 浮动面板按类型自动渲染，无需改动面板代码

## 测试

- 新增 `tests/controlnet_test.py`（16 个用例）：API 字段校验、`load_controlnet`/`load_vae`、三个模型族的节点加载与 denoise 透传、示例脚本 prepare pass —— 全部通过
- 新增 `frontend/ssui_components/test/ControlNetLoader.test.ts`（2 个用例）：组件注册与 `onExecute` 输出结构 —— 全部通过
- 验证：`ssui_components`、Image 扩展、functional_ui 的 `tsc + vite build` 均通过

## 使用

Canvas 中选择 `workflow-sd1.py` 等脚本 → `txt2imgWithControlNet` → 选择 ControlNet 模型、上传控制图（pose/canny/depth 等）、调节权重。已安装模型需重新安装/扫描一次以获得 `controlnet` 标签。
