### PR TITLE
feat(motion): add pose recognition and Blender nodes

### DIFF
--- a/examples/advance/ssproject.yaml
+++ b/examples/advance/ssproject.yaml
@@ -1,3 +1,4 @@
 ssui_version: 0.1.1
 dependencies:
     - numpy = ^1.21.2
+    - ssui_motion = ^0.1.0

--- a/examples/advance/workflow-pose.py
+++ b/examples/advance/workflow-pose.py
@@ -1,0 +1,19 @@
+from ssui import SkeletonAnimation, Video, workflow
+from ssui.config import SSUIConfig
+from ssui_motion import RecognizePose, RenderBlenderComparison
+
+config = SSUIConfig()
+
+
+@workflow
+def video_to_skeleton(video: Video) -> tuple[Video, SkeletonAnimation]:
+    """Extract a smoothed 33-joint animation and a visual verification video."""
+    return RecognizePose(config("Pose Recognition"), video)
+
+
+@workflow
+def video_to_blender_comparison(video: Video) -> tuple[Video, SkeletonAnimation, Video]:
+    """Recognize a video and render the reconstructed BVH side by side in Blender."""
+    overlay, animation = RecognizePose(config("Pose Recognition"), video)
+    comparison = RenderBlenderComparison(config("Blender Comparison"), animation)
+    return overlay, animation, comparison

--- a/extensions/Motion/Readme.md
+++ b/extensions/Motion/Readme.md
@@ -1,0 +1,99 @@
+# Motion / 人体骨骼识别
+
+Motion 扩展从单人视频中提取 MediaPipe Pose 33 关键点，并输出：
+
+- 带骨骼叠加层的 `Video`，用于快速检查识别质量；
+- `SkeletonAnimation`，包含逐帧时间戳、图像归一化坐标、相对 3D/世界坐标和置信度；
+- 执行完成后写入的 JSON 文件，可从骨骼预览器直接下载。
+
+## 工作流
+
+```python
+from ssui import SkeletonAnimation, Video, workflow
+from ssui_motion import PoseRecognitionOptions, recognize_pose
+
+@workflow
+def video_to_skeleton(video: Video) -> tuple[Video, SkeletonAnimation]:
+    options = PoseRecognitionOptions(sample_fps=24, smoothing=0.45)
+    return recognize_pose(video, options)
+```
+
+完整示例见 `examples/advance/workflow-pose.py`。
+
+节点系统会显示两个可执行工作流：
+
+- `video_to_skeleton`：上传视频后输出骨骼叠加视频与可逐帧检查的骨骼动画；
+- `video_to_blender_comparison`：在上述输出之外调用 Blender，追加源骨骼/BVH 并排比对视频。
+
+节点详情面板可调整采样 FPS、平滑强度、检测/跟踪置信度、断帧补偿和本地模型路径。
+Blender 输出节点同时提供 `.blend`、BVH、误差报告和重定向报告下载。
+
+## 模型与离线使用
+
+MediaPipe 旧版环境使用内置 Solutions Pose；新版 Tasks 环境会在首次识别时下载官方
+`pose_landmarker_full.task`，并缓存到 `~/.cache/ssui/mediapipe/`。可以通过以下任一方式改用本地模型：
+
+```python
+PoseRecognitionOptions(model_path="D:/models/pose_landmarker_full.task")
+```
+
+或设置 `SSUI_MODEL_CACHE`，让 SSUI 从指定的模型缓存目录读取。
+
+## BVH 与 Blender 对比
+
+执行器在保存骨骼 JSON 时会同时生成：
+
+- `.bvh`：21 关节人形层级、固定中位骨长、局部 XYZ 旋转和连续欧拉角；
+- `.retarget.json`：原始目标、前向运动学重建结果、逐关节平均误差、RMSE 与最大误差。
+
+将结果在 Blender 中重建并逐帧比对：
+
+```powershell
+blender --background --factory-startup `
+  --python extensions/Motion/blender/reconstruct_and_compare.py -- `
+  --bvh output/skeleton_xxx.bvh `
+  --retarget output/skeleton_xxx.retarget.json `
+  --output-dir output/blender-comparison `
+  --render
+```
+
+输出包括 `pose-comparison.blend`、无损 PNG 帧序列和
+`blender-comparison.json`。渲染画面左侧为原始关键点，右侧为 BVH 重建；数值报告则直接读取
+Blender 导入后的 PoseBone 位置，不依赖渲染图像颜色或抗锯齿。
+
+Windows 上从 Microsoft Store 安装的 Blender 位于受保护的 `WindowsApps` 目录，不能直接通过其
+实际 `blender.exe` 路径启动。此时使用随扩展提供的 MSIX 启动脚本，把相同的后台参数传给 Blender：
+
+```powershell
+$script = (Resolve-Path 'extensions/Motion/blender/reconstruct_and_compare.py').Path
+$bvh = (Resolve-Path 'output/skeleton_xxx.bvh').Path
+$retarget = (Resolve-Path 'output/skeleton_xxx.retarget.json').Path
+$output = Join-Path (Get-Location) 'output/blender-comparison'
+$arguments = '--background --factory-startup --python "{0}" -- --bvh "{1}" --retarget "{2}" --output-dir "{3}" --render' `
+  -f $script, $bvh, $retarget, $output
+
+./extensions/Motion/blender/run_msix_blender.ps1 -Arguments $arguments -Wait
+```
+
+该脚本只调用 Windows 的 MSIX 应用激活 API，不进行桌面自动化。默认应用 ID 对应官方 Store
+版 Blender；普通 ZIP、MSI 或 Steam 版本仍使用前面的 `blender --background` 命令。
+
+### 从真实视频一键生成 Blender 比对
+
+仓库依赖安装完成后，可以用一个命令执行识别、导出和 Blender 渲染：
+
+```powershell
+./extensions/Motion/blender/video_to_blender.ps1 `
+  -Video D:/videos/person.mp4 `
+  -OutputDir output/person-motion
+```
+
+它会生成 `skeleton.json`、`pose-overlay.mp4`、`motion.bvh`、
+`motion.retarget.json`、`pipeline-summary.json`，并在 `blender-comparison/` 中保存
+Blender 场景、误差报告和 PNG 帧。脚本优先使用 PATH 中的普通 Blender；找不到时自动使用官方
+Store/MSIX 版本。通过 `-SkipBlender` 可以只执行视频识别与 BVH 导出。
+
+### 数据边界
+
+MediaPipe 单目世界坐标以髋部为局部原点，无法恢复真实的全局位移。本扩展用画面中的髋部轨迹估计
+相机平面根运动；深度方向根运动、稳定脚底锁定和目标角色的蒙皮骨架重定向仍需要额外约束。

--- a/extensions/Motion/blender/reconstruct_and_compare.py
+++ b/extensions/Motion/blender/reconstruct_and_compare.py
@@ -1,0 +1,210 @@
+"""Import an SSUI BVH into Blender, render a source-vs-rig overlay, and measure it.
+
+Usage:
+  blender --background --python reconstruct_and_compare.py -- \
+    --bvh motion.bvh --retarget motion.retarget.json --output-dir blender-result --render
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+import sys
+
+import bpy
+from mathutils import Vector
+
+
+BONES = (
+    ("Hips", "Spine"), ("Spine", "Chest"), ("Chest", "Neck"), ("Neck", "Head"),
+    ("Chest", "LeftShoulder"), ("LeftShoulder", "LeftArm"), ("LeftArm", "LeftForeArm"), ("LeftForeArm", "LeftHand"),
+    ("Chest", "RightShoulder"), ("RightShoulder", "RightArm"), ("RightArm", "RightForeArm"), ("RightForeArm", "RightHand"),
+    ("Hips", "LeftUpLeg"), ("LeftUpLeg", "LeftLeg"), ("LeftLeg", "LeftFoot"), ("LeftFoot", "LeftToe"),
+    ("Hips", "RightUpLeg"), ("RightUpLeg", "RightLeg"), ("RightLeg", "RightFoot"), ("RightFoot", "RightToe"),
+)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bvh", required=True)
+    parser.add_argument("--retarget", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--render", action="store_true")
+    argv = sys.argv[sys.argv.index("--") + 1:] if "--" in sys.argv else []
+    return parser.parse_args(argv)
+
+
+def clear_scene():
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete(use_global=False)
+    for collection in (bpy.data.meshes, bpy.data.curves, bpy.data.materials, bpy.data.cameras, bpy.data.lights):
+        for item in list(collection):
+            if item.users == 0:
+                collection.remove(item)
+
+
+def material(name, color, emission=0.25):
+    value = bpy.data.materials.new(name)
+    value.diffuse_color = (*color, 1.0)
+    value.use_nodes = True
+    principled = value.node_tree.nodes.get("Principled BSDF")
+    principled.inputs["Base Color"].default_value = (*color, 1.0)
+    principled.inputs["Roughness"].default_value = 0.38
+    if "Emission Color" in principled.inputs:
+        principled.inputs["Emission Color"].default_value = (*color, 1.0)
+        principled.inputs["Emission Strength"].default_value = emission
+    return value
+
+
+def standard_to_blender(value):
+    # BVH X-right/Y-up/Z-forward -> Blender X-right/Y-depth/Z-up.
+    return Vector((value[0], -value[2], value[1]))
+
+
+def make_sphere(name, mat, radius=0.018):
+    bpy.ops.mesh.primitive_ico_sphere_add(subdivisions=2, radius=radius)
+    obj = bpy.context.object
+    obj.name = name
+    obj.data.materials.append(mat)
+    return obj
+
+
+def make_bone(name, mat, radius=0.007):
+    bpy.ops.mesh.primitive_cylinder_add(vertices=10, radius=radius, depth=1.0)
+    obj = bpy.context.object
+    obj.name = name
+    obj.rotation_mode = "QUATERNION"
+    obj.data.materials.append(mat)
+    return obj
+
+
+def place_bone(obj, start, end, frame):
+    delta = end - start
+    length = max(delta.length, 1e-6)
+    obj.location = (start + end) * 0.5
+    obj.rotation_quaternion = Vector((0, 0, 1)).rotation_difference(delta.normalized())
+    obj.scale = (1, 1, length)
+    obj.keyframe_insert("location", frame=frame)
+    obj.keyframe_insert("rotation_quaternion", frame=frame)
+    obj.keyframe_insert("scale", frame=frame)
+
+
+def animate_skeleton(frames, mat, prefix):
+    names = sorted({name for frame in frames for name in frame})
+    joints = {name: make_sphere(f"{prefix}_{name}", mat) for name in names}
+    bones = {(a, b): make_bone(f"{prefix}_{a}_{b}", mat) for a, b in BONES if a in joints and b in joints}
+    for frame_index, data in enumerate(frames, 1):
+        positions = {name: standard_to_blender(value) for name, value in data.items()}
+        for name, obj in joints.items():
+            if name not in positions:
+                obj.hide_render = True
+                obj.keyframe_insert("hide_render", frame=frame_index)
+                continue
+            obj.hide_render = False
+            obj.location = positions[name]
+            obj.keyframe_insert("hide_render", frame=frame_index)
+            obj.keyframe_insert("location", frame=frame_index)
+        for pair, obj in bones.items():
+            if pair[0] in positions and pair[1] in positions:
+                place_bone(obj, positions[pair[0]], positions[pair[1]], frame_index)
+    return joints
+
+
+def add_camera(display_frames):
+    all_points = [standard_to_blender(value) for frame in display_frames for value in frame.values()]
+    low = Vector((min(p.x for p in all_points), min(p.y for p in all_points), min(p.z for p in all_points)))
+    high = Vector((max(p.x for p in all_points), max(p.y for p in all_points), max(p.z for p in all_points)))
+    center = (low + high) * 0.5
+    extent = max(high.x - low.x, high.z - low.z, 0.5)
+    bpy.ops.object.camera_add(location=(center.x, center.y - extent * 3.0, center.z))
+    camera = bpy.context.object
+    camera.data.type = "ORTHO"
+    camera.data.ortho_scale = extent * 1.35
+    camera.rotation_euler = (math.radians(90), 0, 0)
+    bpy.context.scene.camera = camera
+
+
+def shifted(frames, amount):
+    return [
+        {name: [value[0] + amount, value[1], value[2]] for name, value in frame.items()}
+        for frame in frames
+    ]
+
+
+def compare_in_blender(scene, armature, targets):
+    errors = {}
+    samples = []
+    for frame_index, target in enumerate(targets, 1):
+        scene.frame_set(frame_index)
+        for name, value in target.items():
+            if name not in armature.pose.bones:
+                continue
+            expected = standard_to_blender(value)
+            actual = armature.matrix_world @ armature.pose.bones[name].head
+            error = (actual - expected).length
+            errors.setdefault(name, []).append(error)
+            samples.append(error)
+    return {
+        "schema": "ssui.motion.blender-comparison/v1",
+        "blender_version": bpy.app.version_string,
+        "frames": len(targets),
+        "samples": len(samples),
+        "rmse": math.sqrt(sum(value * value for value in samples) / len(samples)) if samples else 0.0,
+        "max_error": max(samples, default=0.0),
+        "per_joint_mean": {name: sum(values) / len(values) for name, values in errors.items()},
+        "units": "Blender units",
+    }
+
+
+def main():
+    args = parse_args()
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    data = json.loads(Path(args.retarget).read_text(encoding="utf-8"))
+    targets = data["target"]
+    reconstructed = data["reconstructed"]
+    clear_scene()
+    bpy.ops.import_anim.bvh(
+        filepath=str(Path(args.bvh).resolve()), axis_forward="-Z", axis_up="Y",
+        global_scale=1.0, frame_start=1, use_fps_scale=False, update_scene_fps=True,
+        rotate_mode="NATIVE",
+    )
+    armature = bpy.context.object
+    armature.name = "SSUI_Retargeted_Rig"
+    armature.show_in_front = True
+    target_mat = material("Source pose · amber", (1.0, 0.46, 0.08), 0.5)
+    rig_mat = material("BVH reconstruction · cyan", (0.06, 0.82, 0.88), 0.7)
+    all_x = [value[0] for frame in targets for value in frame.values()]
+    comparison_gap = max(max(all_x) - min(all_x), 0.5) * 1.25
+    source_display = shifted(targets, -comparison_gap * 0.5)
+    rig_display = shifted(reconstructed, comparison_gap * 0.5)
+    animate_skeleton(source_display, target_mat, "Source")
+    animate_skeleton(rig_display, rig_mat, "BVH")
+    add_camera(source_display + rig_display)
+
+    scene = bpy.context.scene
+    scene.frame_start = 1
+    scene.frame_end = len(targets)
+    scene.render.engine = "BLENDER_EEVEE"
+    scene.render.resolution_x = 960
+    scene.render.resolution_y = 960
+    scene.render.resolution_percentage = 100
+    frames_dir = output_dir / "frames"
+    frames_dir.mkdir(exist_ok=True)
+    scene.render.image_settings.file_format = "PNG"
+    scene.render.image_settings.color_mode = "RGBA"
+    scene.render.filepath = str(frames_dir / "pose-comparison-")
+    scene.world.color = (0.008, 0.015, 0.02)
+
+    report = compare_in_blender(scene, armature, targets)
+    (output_dir / "blender-comparison.json").write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+    bpy.ops.wm.save_as_mainfile(filepath=str(output_dir / "pose-comparison.blend"))
+    if args.render:
+        bpy.ops.render.render(animation=True)
+    print("SSUI_BLENDER_REPORT=" + json.dumps(report, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/extensions/Motion/blender/run_msix_blender.ps1
+++ b/extensions/Motion/blender/run_msix_blender.ps1
@@ -1,0 +1,74 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Arguments,
+
+    [string]$AppUserModelId = 'BlenderFoundation.Blender_ppwjx1n5r4v9t!BLENDER',
+
+    [switch]$Wait
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not ('Ssui.ApplicationActivationManager' -as [type])) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+namespace Ssui
+{
+    [Flags]
+    public enum ActivateOptions
+    {
+        None = 0,
+        DesignMode = 1,
+        NoErrorUI = 2,
+        NoSplashScreen = 4
+    }
+
+    [ComImport]
+    [Guid("2e941141-7f97-4756-ba1d-9decde894a3d")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IApplicationActivationManager
+    {
+        int ActivateApplication(
+            [MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
+            [MarshalAs(UnmanagedType.LPWStr)] string arguments,
+            ActivateOptions options,
+            out uint processId);
+
+        int ActivateForFile(IntPtr appUserModelId, IntPtr itemArray, IntPtr verb, out uint processId);
+        int ActivateForProtocol(IntPtr appUserModelId, IntPtr itemArray, out uint processId);
+    }
+
+    [ComImport]
+    [Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]
+    class ApplicationActivationManagerClass
+    {
+    }
+
+    public static class ApplicationActivationManager
+    {
+        public static uint Activate(string appUserModelId, string arguments)
+        {
+            var manager = (IApplicationActivationManager)new ApplicationActivationManagerClass();
+            uint processId;
+            int result = manager.ActivateApplication(
+                appUserModelId,
+                arguments,
+                ActivateOptions.NoErrorUI | ActivateOptions.NoSplashScreen,
+                out processId);
+            Marshal.ThrowExceptionForHR(result);
+            return processId;
+        }
+    }
+}
+'@
+}
+
+$processId = [Ssui.ApplicationActivationManager]::Activate($AppUserModelId, $Arguments)
+Write-Output "Activated $AppUserModelId as process $processId"
+
+if ($Wait) {
+    Wait-Process -Id $processId
+    Write-Output "Process $processId exited"
+}

--- a/extensions/Motion/blender/video_to_blender.ps1
+++ b/extensions/Motion/blender/video_to_blender.ps1
@@ -1,0 +1,88 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Video,
+    [string]$OutputDir = 'output/video-to-blender',
+    [double]$SampleFps = 24.0,
+    [double]$Smoothing = 0.45,
+    [string]$ModelPath,
+    [string]$PythonExecutable,
+    [string]$BlenderExecutable,
+    [switch]$SkipBlender
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path
+$videoPath = (Resolve-Path $Video).Path
+$outputPath = if ([System.IO.Path]::IsPathRooted($OutputDir)) {
+    [System.IO.Path]::GetFullPath($OutputDir)
+} else {
+    [System.IO.Path]::GetFullPath((Join-Path (Get-Location) $OutputDir))
+}
+$motionScript = Join-Path $PSScriptRoot 'video_to_motion.py'
+
+if (-not $PythonExecutable) {
+    $PythonExecutable = Join-Path $repoRoot '.venv\Scripts\python.exe'
+}
+if (-not (Test-Path -LiteralPath $PythonExecutable -PathType Leaf)) {
+    throw "SSUI Python environment not found: $PythonExecutable. Run yarn first or pass -PythonExecutable."
+}
+
+$motionArgs = @(
+    $motionScript,
+    '--video', $videoPath,
+    '--output-dir', $outputPath,
+    '--sample-fps', $SampleFps.ToString([Globalization.CultureInfo]::InvariantCulture),
+    '--smoothing', $Smoothing.ToString([Globalization.CultureInfo]::InvariantCulture)
+)
+if ($ModelPath) {
+    $motionArgs += @('--model-path', (Resolve-Path $ModelPath).Path)
+}
+
+& $PythonExecutable @motionArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "Pose recognition failed with exit code $LASTEXITCODE"
+}
+if ($SkipBlender) {
+    return
+}
+
+$compareScript = Join-Path $PSScriptRoot 'reconstruct_and_compare.py'
+$bvhPath = Join-Path $outputPath 'motion.bvh'
+$retargetPath = Join-Path $outputPath 'motion.retarget.json'
+$blenderOutput = Join-Path $outputPath 'blender-comparison'
+$blenderArgs = @(
+    '--background', '--factory-startup',
+    '--python', $compareScript, '--',
+    '--bvh', $bvhPath,
+    '--retarget', $retargetPath,
+    '--output-dir', $blenderOutput,
+    '--render'
+)
+
+if (-not $BlenderExecutable) {
+    $command = Get-Command blender.exe -ErrorAction SilentlyContinue
+    if ($command) {
+        $BlenderExecutable = $command.Source
+    }
+}
+
+if ($BlenderExecutable) {
+    & $BlenderExecutable @blenderArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "Blender comparison failed with exit code $LASTEXITCODE"
+    }
+} else {
+    function Quote-Argument([string]$Value) {
+        return '"' + $Value.Replace('"', '\"') + '"'
+    }
+
+    $argumentLine = ($blenderArgs | ForEach-Object { Quote-Argument ([string]$_) }) -join ' '
+    & (Join-Path $PSScriptRoot 'run_msix_blender.ps1') -Arguments $argumentLine -Wait
+}
+
+$comparisonPath = Join-Path $blenderOutput 'blender-comparison.json'
+$scenePath = Join-Path $blenderOutput 'pose-comparison.blend'
+if (-not (Test-Path -LiteralPath $comparisonPath -PathType Leaf) -or
+    -not (Test-Path -LiteralPath $scenePath -PathType Leaf)) {
+    throw "Blender exited without producing the expected comparison artifacts in $blenderOutput"
+}

--- a/extensions/Motion/blender/video_to_motion.py
+++ b/extensions/Motion/blender/video_to_motion.py
@@ -1,0 +1,99 @@
+"""Convert a person video into SSUI pose data and Blender-ready BVH files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from ssui import Video
+from ssui_motion import PoseRecognitionOptions, export_bvh, recognize_pose
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Recognize a single-person video and export SSUI Motion artifacts."
+    )
+    parser.add_argument("--video", required=True, help="Input video file")
+    parser.add_argument("--output-dir", required=True, help="Artifact directory")
+    parser.add_argument("--sample-fps", type=float, default=24.0)
+    parser.add_argument("--smoothing", type=float, default=0.45)
+    parser.add_argument("--model-path")
+    return parser.parse_args()
+
+
+def write_overlay(frames, fps: float, path: Path) -> None:
+    if not frames:
+        raise ValueError("Pose recognition produced no overlay frames")
+    width, height = frames[0].size
+    writer = cv2.VideoWriter(
+        str(path), cv2.VideoWriter_fourcc(*"mp4v"), fps, (width, height)
+    )
+    if not writer.isOpened():
+        raise RuntimeError(f"Cannot create overlay video: {path}")
+    try:
+        for frame in frames:
+            if frame.size != (width, height):
+                raise ValueError("Input video changed resolution between frames")
+            writer.write(cv2.cvtColor(np.asarray(frame), cv2.COLOR_RGB2BGR))
+    finally:
+        writer.release()
+
+
+def main() -> int:
+    args = parse_args()
+    video_path = Path(args.video).expanduser().resolve()
+    if not video_path.is_file():
+        raise FileNotFoundError(f"Input video not found: {video_path}")
+
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    options = PoseRecognitionOptions(
+        model_path=args.model_path,
+        sample_fps=args.sample_fps,
+        smoothing=args.smoothing,
+    )
+    overlay, animation = recognize_pose(Video(path=str(video_path)), options)
+    detected_frames = sum(frame.detected for frame in animation.frames)
+    landmark_frames = sum(bool(frame.landmarks) for frame in animation.frames)
+    if landmark_frames == 0:
+        raise RuntimeError("No person pose was recognized in the input video")
+
+    skeleton_path = output_dir / "skeleton.json"
+    overlay_path = output_dir / "pose-overlay.mp4"
+    bvh_path = output_dir / "motion.bvh"
+    skeleton_path.write_text(
+        json.dumps(animation.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    write_overlay(overlay.frames, animation.fps, overlay_path)
+    bvh = export_bvh(animation, bvh_path)
+
+    result = {
+        "schema": "ssui.motion.video-pipeline/v1",
+        "source": str(video_path),
+        "frames": len(animation.frames),
+        "detected_frames": detected_frames,
+        "landmark_frames": landmark_frames,
+        "fps": animation.fps,
+        "artifacts": {
+            "skeleton": str(skeleton_path),
+            "overlay": str(overlay_path),
+            "bvh": str(bvh_path),
+            "retarget": str(bvh_path.with_suffix(".retarget.json")),
+        },
+        "retarget_rmse": bvh.report["rmse"],
+        "retarget_max_error": bvh.report["max_error"],
+    }
+    summary_path = output_dir / "pipeline-summary.json"
+    summary_path.write_text(
+        json.dumps(result, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/extensions/Motion/extension.py
+++ b/extensions/Motion/extension.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+
+
+app = APIRouter()
+
+
+@app.get("/version")
+async def version():
+    return {"name": "Motion", "version": "0.1.0"}

--- a/extensions/Motion/ssextension.yaml
+++ b/extensions/Motion/ssextension.yaml
@@ -2,11 +2,16 @@ name: Motion
 version: 0.1.0
 server:
   venv: shared
+  packages:
+    - ssui_motion
   dependencies:
     - numpy>=1.21.2
+    - mediapipe>=0.10.21
+    - opencv-python-headless>=4.11.0.86
+    - Pillow>=10.0.0
+    - scipy>=1.15.0
   main: extension.py
 
 web_ui:
   dist: dist/
   main: main.js
-  

--- a/extensions/Motion/ssui_motion/__init__.py
+++ b/extensions/Motion/ssui_motion/__init__.py
@@ -1,0 +1,12 @@
+"""Human pose recognition tools for SSUI workflows."""
+
+from .pose import MediaPipePoseDetector, PoseRecognitionOptions, recognize_pose
+from .bvh import BVHExport, export_bvh, to_bvh
+from .blender import render_blender_comparison
+from .nodes import RecognizePose, RenderBlenderComparison
+
+__all__ = [
+    "BVHExport", "MediaPipePoseDetector", "PoseRecognitionOptions",
+    "RecognizePose", "RenderBlenderComparison", "export_bvh",
+    "recognize_pose", "render_blender_comparison", "to_bvh",
+]

--- a/extensions/Motion/ssui_motion/blender.py
+++ b/extensions/Motion/ssui_motion/blender.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import uuid
+
+from PIL import Image as PILImage
+
+from ssui import SkeletonAnimation, Video
+
+from .bvh import export_bvh
+
+
+def _output_root(animation: SkeletonAnimation) -> Path:
+    if animation.source:
+        source = Path(animation.source).expanduser().resolve()
+        if source.parent.name.lower() == "input":
+            return source.parent.parent / "output"
+    return Path.cwd() / "output"
+
+
+def _blender_executable(explicit: str | None) -> str | None:
+    if explicit:
+        path = Path(explicit).expanduser()
+        if not path.is_file():
+            raise FileNotFoundError(f"Blender executable not found: {path}")
+        return str(path.resolve())
+    configured = os.environ.get("BLENDER_EXECUTABLE")
+    if configured:
+        return _blender_executable(configured)
+    command = shutil.which("blender") or shutil.which("blender.exe")
+    if command:
+        return command
+    candidates = []
+    if sys.platform == "darwin":
+        candidates.append(Path("/Applications/Blender.app/Contents/MacOS/Blender"))
+    elif os.name == "nt":
+        program_files = Path(os.environ.get("ProgramFiles", "C:/Program Files"))
+        candidates.extend(sorted(
+            (program_files / "Blender Foundation").glob("Blender */blender.exe"),
+            reverse=True,
+        ))
+    return str(candidates[0]) if candidates else None
+
+
+def _run_blender(arguments: list[str], explicit: str | None) -> None:
+    executable = _blender_executable(explicit)
+    if executable:
+        subprocess.run([executable, *arguments], check=True)
+        return
+    if os.name != "nt":
+        raise RuntimeError(
+            "Blender was not found. Add it to PATH or set BLENDER_EXECUTABLE."
+        )
+
+    helper = Path(__file__).resolve().parent.parent / "blender" / "run_msix_blender.ps1"
+    if not helper.is_file():
+        raise RuntimeError("The Blender MSIX launcher is missing from the Motion extension")
+    powershell = shutil.which("pwsh") or shutil.which("powershell")
+    if not powershell:
+        raise RuntimeError("PowerShell is required to launch Microsoft Store Blender")
+    subprocess.run([
+        powershell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(helper),
+        "-Arguments", subprocess.list2cmdline(arguments), "-Wait",
+    ], check=True)
+
+
+def render_blender_comparison(
+    animation: SkeletonAnimation,
+    output_dir: str | Path | None = None,
+    blender_executable: str | None = None,
+) -> Video:
+    """Render source landmarks beside Blender's imported BVH reconstruction."""
+
+    if not animation.frames:
+        raise ValueError("Skeleton animation has no frames")
+    root = Path(output_dir).expanduser().resolve() if output_dir else (
+        _output_root(animation) / f"blender_comparison_{uuid.uuid4().hex}"
+    )
+    root.mkdir(parents=True, exist_ok=True)
+    bvh_path = root / "motion.bvh"
+    export = export_bvh(animation, bvh_path)
+    retarget_path = bvh_path.with_suffix(".retarget.json")
+    script = Path(__file__).resolve().parent.parent / "blender" / "reconstruct_and_compare.py"
+    arguments = [
+        "--background", "--factory-startup", "--python", str(script), "--",
+        "--bvh", str(bvh_path), "--retarget", str(retarget_path),
+        "--output-dir", str(root), "--render",
+    ]
+    _run_blender(arguments, blender_executable)
+
+    scene_path = root / "pose-comparison.blend"
+    report_path = root / "blender-comparison.json"
+    frame_paths = sorted((root / "frames").glob("pose-comparison-*.png"))
+    if not scene_path.is_file() or not report_path.is_file() or not frame_paths:
+        raise RuntimeError(f"Blender did not produce complete comparison artifacts in {root}")
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    frames = []
+    for path in frame_paths:
+        with PILImage.open(path) as image:
+            frames.append(image.convert("RGB").copy())
+    return Video(
+        "mp4", frames=frames, fps=animation.fps,
+        metadata={
+            "kind": "blender_comparison",
+            "scene_path": str(scene_path),
+            "report_path": str(report_path),
+            "bvh_path": str(bvh_path),
+            "retarget_path": str(retarget_path),
+            "blender_version": report.get("blender_version"),
+            "comparison_rmse": report.get("rmse"),
+            "comparison_max_error": report.get("max_error"),
+            "source_retarget_rmse": export.report.get("rmse"),
+        },
+    )

--- a/extensions/Motion/ssui_motion/bvh.py
+++ b/extensions/Motion/ssui_motion/bvh.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from ssui import PoseFrame, PoseLandmark, SkeletonAnimation
+
+
+@dataclass(frozen=True)
+class JointSpec:
+    name: str
+    parent: str | None
+    source: str | tuple[str, str]
+    canonical_axis: tuple[float, float, float]
+    primary_child: str | None = None
+
+
+JOINTS = (
+    JointSpec("Hips", None, ("left_hip", "right_hip"), (0, 1, 0), "Spine"),
+    JointSpec("Spine", "Hips", ("left_hip", "right_hip"), (0, 1, 0), "Chest"),
+    JointSpec("Chest", "Spine", ("left_shoulder", "right_shoulder"), (0, 1, 0), "Neck"),
+    JointSpec("Neck", "Chest", ("left_shoulder", "right_shoulder"), (0, 1, 0), "Head"),
+    JointSpec("Head", "Neck", "nose", (0, 1, 0)),
+    JointSpec("LeftShoulder", "Chest", "left_shoulder", (-1, 0, 0), "LeftArm"),
+    JointSpec("LeftArm", "LeftShoulder", "left_elbow", (-1, 0, 0), "LeftForeArm"),
+    JointSpec("LeftForeArm", "LeftArm", "left_wrist", (-1, 0, 0), "LeftHand"),
+    JointSpec("LeftHand", "LeftForeArm", "left_index", (-1, 0, 0)),
+    JointSpec("RightShoulder", "Chest", "right_shoulder", (1, 0, 0), "RightArm"),
+    JointSpec("RightArm", "RightShoulder", "right_elbow", (1, 0, 0), "RightForeArm"),
+    JointSpec("RightForeArm", "RightArm", "right_wrist", (1, 0, 0), "RightHand"),
+    JointSpec("RightHand", "RightForeArm", "right_index", (1, 0, 0)),
+    JointSpec("LeftUpLeg", "Hips", "left_hip", (-1, 0, 0), "LeftLeg"),
+    JointSpec("LeftLeg", "LeftUpLeg", "left_knee", (0, -1, 0), "LeftFoot"),
+    JointSpec("LeftFoot", "LeftLeg", "left_ankle", (0, -1, 0), "LeftToe"),
+    JointSpec("LeftToe", "LeftFoot", "left_foot_index", (0, 0, -1)),
+    JointSpec("RightUpLeg", "Hips", "right_hip", (1, 0, 0), "RightLeg"),
+    JointSpec("RightLeg", "RightUpLeg", "right_knee", (0, -1, 0), "RightFoot"),
+    JointSpec("RightFoot", "RightLeg", "right_ankle", (0, -1, 0), "RightToe"),
+    JointSpec("RightToe", "RightFoot", "right_foot_index", (0, 0, -1)),
+)
+JOINT_BY_NAME = {joint.name: joint for joint in JOINTS}
+CHILDREN = {joint.name: [child.name for child in JOINTS if child.parent == joint.name] for joint in JOINTS}
+
+
+@dataclass
+class BVHExport:
+    content: str
+    report: dict
+
+
+def _point_map(frame: PoseFrame) -> dict[str, PoseLandmark]:
+    return {point.name: point for point in frame.landmarks}
+
+
+def _raw_point(point: PoseLandmark, animation: SkeletonAnimation) -> np.ndarray:
+    if point.world_x is not None and point.world_y is not None and point.world_z is not None:
+        # BVH convention: X right, Y up, Z forward. Blender converts this to Z-up.
+        return np.array((point.world_x, point.world_y, point.world_z), dtype=float)
+    aspect = animation.width / animation.height if animation.height else 1.0
+    return np.array(((point.x - 0.5) * aspect, 0.5 - point.y, point.z), dtype=float)
+
+
+def joint_positions(frame: PoseFrame, animation: SkeletonAnimation) -> dict[str, np.ndarray]:
+    points = _point_map(frame)
+
+    def source(value: str | tuple[str, str]) -> np.ndarray | None:
+        names = (value,) if isinstance(value, str) else value
+        found = [_raw_point(points[name], animation) for name in names if name in points]
+        return np.mean(found, axis=0) if len(found) == len(names) else None
+
+    positions = {joint.name: source(joint.source) for joint in JOINTS}
+    hips = positions["Hips"]
+    chest = positions["Chest"]
+    if hips is not None and chest is not None:
+        positions["Spine"] = hips * 0.5 + chest * 0.5
+        shoulder_width = np.linalg.norm(
+            _raw_point(points["right_shoulder"], animation) - _raw_point(points["left_shoulder"], animation)
+        ) if "left_shoulder" in points and "right_shoulder" in points else 0.2
+        positions["Neck"] = chest + _safe_unit(chest - hips) * shoulder_width * 0.18
+    return {name: value for name, value in positions.items() if value is not None}
+
+
+def _safe_unit(vector: np.ndarray, fallback=(0.0, 1.0, 0.0)) -> np.ndarray:
+    length = float(np.linalg.norm(vector))
+    return vector / length if length > 1e-8 else np.asarray(fallback, dtype=float)
+
+
+def _rotation_between(source: np.ndarray, target: np.ndarray) -> np.ndarray:
+    a, b = _safe_unit(source), _safe_unit(target)
+    cross = np.cross(a, b)
+    dot = float(np.clip(np.dot(a, b), -1.0, 1.0))
+    if dot < -0.999999:
+        helper = np.array((1.0, 0.0, 0.0)) if abs(a[0]) < 0.9 else np.array((0.0, 0.0, 1.0))
+        axis = _safe_unit(np.cross(a, helper))
+        return Rotation.from_rotvec(axis * math.pi).as_matrix()
+    skew = np.array(((0, -cross[2], cross[1]), (cross[2], 0, -cross[0]), (-cross[1], cross[0], 0)))
+    return np.eye(3) + skew + skew @ skew / max(1e-8, 1 + dot)
+
+
+def _body_frame(up: np.ndarray, right: np.ndarray) -> np.ndarray:
+    y = _safe_unit(up)
+    x = _safe_unit(right - y * np.dot(right, y), (1, 0, 0))
+    z = _safe_unit(np.cross(x, y), (0, 0, 1))
+    x = _safe_unit(np.cross(y, z), (1, 0, 0))
+    return np.column_stack((x, y, z))
+
+
+def _valid_frames(animation: SkeletonAnimation):
+    return [(frame, joint_positions(frame, animation)) for frame in animation.frames if frame.landmarks]
+
+
+def _offsets(frames: list[tuple[PoseFrame, dict[str, np.ndarray]]]) -> dict[str, np.ndarray]:
+    result = {"Hips": np.zeros(3)}
+    for joint in JOINTS[1:]:
+        lengths = []
+        for _, positions in frames:
+            if joint.name in positions and joint.parent in positions:
+                lengths.append(float(np.linalg.norm(positions[joint.name] - positions[joint.parent])))
+        length = float(np.median(lengths)) if lengths else 0.1
+        result[joint.name] = _safe_unit(np.asarray(joint.canonical_axis, dtype=float)) * max(length, 1e-4)
+    return result
+
+
+def _world_rotations(positions: dict[str, np.ndarray], offsets: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+    rotations: dict[str, np.ndarray] = {}
+    hips, chest = positions.get("Hips"), positions.get("Chest")
+    left_hip, right_hip = positions.get("LeftUpLeg"), positions.get("RightUpLeg")
+    if hips is not None and chest is not None and left_hip is not None and right_hip is not None:
+        rotations["Hips"] = _body_frame(chest - hips, right_hip - left_hip)
+    else:
+        rotations["Hips"] = np.eye(3)
+    for joint in JOINTS[1:]:
+        if joint.name == "Chest" and all(name in positions for name in ("Spine", "Neck", "LeftShoulder", "RightShoulder")):
+            rotations[joint.name] = _body_frame(
+                positions["Neck"] - positions["Spine"], positions["RightShoulder"] - positions["LeftShoulder"]
+            )
+        elif joint.primary_child and joint.name in positions and joint.primary_child in positions:
+            rotations[joint.name] = _rotation_between(
+                offsets[joint.primary_child], positions[joint.primary_child] - positions[joint.name]
+            )
+        else:
+            parent_rotation = rotations.get(joint.parent, np.eye(3))
+            rotations[joint.name] = parent_rotation
+    return rotations
+
+
+def _screen_root(frame: PoseFrame, animation: SkeletonAnimation, scale: float) -> np.ndarray:
+    points = _point_map(frame)
+    if "left_hip" not in points or "right_hip" not in points:
+        return np.zeros(3)
+    hip_x = (points["left_hip"].x + points["right_hip"].x) * 0.5
+    hip_y = (points["left_hip"].y + points["right_hip"].y) * 0.5
+    aspect = animation.width / animation.height if animation.height else 1.0
+    return np.array(((hip_x - 0.5) * aspect * scale, (0.5 - hip_y) * scale, 0.0))
+
+
+def _motion(animation: SkeletonAnimation, frames, offsets):
+    rows = []
+    local_matrices = []
+    root_scale = sum(np.linalg.norm(offset) for name, offset in offsets.items() if "Leg" in name) or 1.0
+    base_screen = _screen_root(frames[0][0], animation, root_scale)
+    for frame, positions in frames:
+        world = _world_rotations(positions, offsets)
+        locals_for_frame = {}
+        root_position = positions.get("Hips", np.zeros(3)) + _screen_root(frame, animation, root_scale) - base_screen
+        values = list(root_position)
+        for joint in JOINTS:
+            parent_world = world.get(joint.parent, np.eye(3))
+            local = parent_world.T @ world.get(joint.name, parent_world)
+            locals_for_frame[joint.name] = local
+            values.extend(Rotation.from_matrix(local).as_euler("XYZ", degrees=False))
+        rows.append(np.asarray(values, dtype=float))
+        local_matrices.append(locals_for_frame)
+    matrix = np.vstack(rows)
+    matrix[:, 3:] = np.unwrap(matrix[:, 3:], axis=0)
+    matrix[:, 3:] = np.degrees(matrix[:, 3:])
+    return matrix, local_matrices
+
+
+def _hierarchy(name: str, offsets: dict[str, np.ndarray], indent=0) -> list[str]:
+    joint = JOINT_BY_NAME[name]
+    prefix = "  " * indent
+    lines = [f"{prefix}{'ROOT' if joint.parent is None else 'JOINT'} {name}", f"{prefix}{{"]
+    offset = offsets[name]
+    lines.append(f"{prefix}  OFFSET {offset[0]:.8f} {offset[1]:.8f} {offset[2]:.8f}")
+    channels = "6 Xposition Yposition Zposition Xrotation Yrotation Zrotation" if joint.parent is None else "3 Xrotation Yrotation Zrotation"
+    lines.append(f"{prefix}  CHANNELS {channels}")
+    children = CHILDREN[name]
+    for child in children:
+        lines.extend(_hierarchy(child, offsets, indent + 1))
+    if not children:
+        axis = _safe_unit(offset) * max(np.linalg.norm(offset) * 0.25, 0.01)
+        lines.extend((f"{prefix}  End Site", f"{prefix}  {{", f"{prefix}    OFFSET {axis[0]:.8f} {axis[1]:.8f} {axis[2]:.8f}", f"{prefix}  }}"))
+    lines.append(f"{prefix}}}")
+    return lines
+
+
+def _forward_kinematics(root, locals_for_frame, offsets):
+    positions = {"Hips": np.asarray(root, dtype=float)}
+    world = {}
+    for joint in JOINTS:
+        parent_world = world.get(joint.parent, np.eye(3))
+        world[joint.name] = parent_world @ locals_for_frame[joint.name]
+        if joint.parent:
+            positions[joint.name] = positions[joint.parent] + parent_world @ offsets[joint.name]
+    return positions
+
+
+def _report(animation, frames, offsets, motion, local_matrices):
+    errors: dict[str, list[float]] = {joint.name: [] for joint in JOINTS}
+    reconstructed = []
+    targets = []
+    for index, ((_, target), local) in enumerate(zip(frames, local_matrices)):
+        result = _forward_kinematics(motion[index, :3], local, offsets)
+        reconstructed.append({name: value.tolist() for name, value in result.items()})
+        target_root = target.get("Hips", np.zeros(3))
+        aligned_target = {name: value - target_root + motion[index, :3] for name, value in target.items()}
+        targets.append({name: value.tolist() for name, value in aligned_target.items()})
+        for name in result.keys() & target.keys():
+            errors[name].append(float(np.linalg.norm(result[name] - aligned_target[name])))
+    samples = [value for values in errors.values() for value in values]
+    return {
+        "schema": "ssui.motion.retarget-report/v1",
+        "frames": len(frames),
+        "rmse": math.sqrt(sum(value * value for value in samples) / len(samples)) if samples else 0.0,
+        "max_error": max(samples, default=0.0),
+        "per_joint_mean": {name: float(np.mean(values)) if values else None for name, values in errors.items()},
+        "units": "mediapipe-world-meters-or-normalized-fallback",
+        "root_motion": "screen-space-estimate; monocular metric translation unavailable",
+        "target": targets,
+        "reconstructed": reconstructed,
+    }
+
+
+def to_bvh(animation: SkeletonAnimation) -> BVHExport:
+    frames = _valid_frames(animation)
+    if not frames:
+        raise ValueError("Skeleton animation has no frames with landmarks")
+    offsets = _offsets(frames)
+    motion, local_matrices = _motion(animation, frames, offsets)
+    lines = ["HIERARCHY", *_hierarchy("Hips", offsets), "MOTION", f"Frames: {len(frames)}", f"Frame Time: {1.0 / animation.fps:.9f}"]
+    lines.extend(" ".join(f"{value:.7f}" for value in row) for row in motion)
+    report = _report(animation, frames, offsets, motion, local_matrices)
+    return BVHExport("\n".join(lines) + "\n", report)
+
+
+def export_bvh(animation: SkeletonAnimation, path: str | Path) -> BVHExport:
+    result = to_bvh(animation)
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(result.content, encoding="utf-8")
+    output.with_suffix(".retarget.json").write_text(json.dumps(result.report, ensure_ascii=False, indent=2), encoding="utf-8")
+    return result

--- a/extensions/Motion/ssui_motion/nodes.py
+++ b/extensions/Motion/ssui_motion/nodes.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from ssui import SkeletonAnimation, Video
+from ssui.annotation import param
+from ssui.config import SSUIConfig
+from ssui.controller import Input, Slider
+
+from .blender import render_blender_comparison
+from .pose import PoseRecognitionOptions, recognize_pose
+
+
+@param("sample_fps", Slider(1, 60, 1), default=24)
+@param("smoothing", Slider(0, 0.95, 0.05), default=0.45)
+@param("detection_confidence", Slider(0, 1, 0.05), default=0.5)
+@param("tracking_confidence", Slider(0, 1, 0.05), default=0.5)
+@param("max_gap_frames", Slider(0, 12, 1), default=3)
+@param("model_path", Input("可选：本地 pose_landmarker .task 路径"), default="")
+def RecognizePose(config: SSUIConfig, video: Video) -> tuple[Video, SkeletonAnimation]:
+    """Configurable SSUI node for single-person pose recognition."""
+
+    if config.is_prepare():
+        return Video(), SkeletonAnimation()
+    model_path = config["model_path"] or None
+    options = PoseRecognitionOptions(
+        model_path=model_path,
+        sample_fps=float(config["sample_fps"]),
+        min_detection_confidence=float(config["detection_confidence"]),
+        min_tracking_confidence=float(config["tracking_confidence"]),
+        smoothing=float(config["smoothing"]),
+        max_gap_frames=int(config["max_gap_frames"]),
+    )
+    return recognize_pose(video, options)
+
+
+@param("blender_executable", Input("可选：blender 可执行文件路径"), default="")
+def RenderBlenderComparison(config: SSUIConfig, animation: SkeletonAnimation) -> Video:
+    """Configurable SSUI node that renders and measures a BVH in Blender."""
+
+    if config.is_prepare():
+        return Video()
+    executable = config["blender_executable"] or None
+    return render_blender_comparison(animation, blender_executable=executable)

--- a/extensions/Motion/ssui_motion/pose.py
+++ b/extensions/Motion/ssui_motion/pose.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+from typing import Protocol, Sequence
+from urllib.error import URLError
+from urllib.request import urlopen
+
+import numpy as np
+from PIL import Image as PILImage, ImageDraw
+
+from ssui import PoseFrame, PoseLandmark, SkeletonAnimation, Video
+
+
+LANDMARK_NAMES = (
+    "nose", "left_eye_inner", "left_eye", "left_eye_outer", "right_eye_inner",
+    "right_eye", "right_eye_outer", "left_ear", "right_ear", "mouth_left",
+    "mouth_right", "left_shoulder", "right_shoulder", "left_elbow", "right_elbow",
+    "left_wrist", "right_wrist", "left_pinky", "right_pinky", "left_index",
+    "right_index", "left_thumb", "right_thumb", "left_hip", "right_hip",
+    "left_knee", "right_knee", "left_ankle", "right_ankle", "left_heel",
+    "right_heel", "left_foot_index", "right_foot_index",
+)
+
+POSE_CONNECTIONS = (
+    (0, 2), (2, 5), (5, 0), (2, 7), (5, 8), (9, 10),
+    (11, 12), (11, 13), (13, 15), (15, 17), (15, 19), (15, 21),
+    (12, 14), (14, 16), (16, 18), (16, 20), (16, 22),
+    (11, 23), (12, 24), (23, 24), (23, 25), (25, 27), (27, 29),
+    (29, 31), (27, 31), (24, 26), (26, 28), (28, 30), (30, 32), (28, 32),
+)
+
+POSE_MODEL_URL = (
+    "https://storage.googleapis.com/mediapipe-models/pose_landmarker/"
+    "pose_landmarker_full/float16/1/pose_landmarker_full.task"
+)
+
+
+@dataclass(frozen=True)
+class PoseRecognitionOptions:
+    model_path: str | None = None
+    sample_fps: float | None = None
+    min_detection_confidence: float = 0.5
+    min_tracking_confidence: float = 0.5
+    smoothing: float = 0.45
+    max_gap_frames: int = 3
+    draw_confidence: float = 0.35
+
+    def __post_init__(self):
+        if self.sample_fps is not None and self.sample_fps <= 0:
+            raise ValueError("sample_fps must be positive")
+        for name in ("min_detection_confidence", "min_tracking_confidence", "smoothing", "draw_confidence"):
+            value = getattr(self, name)
+            if not 0 <= value <= 1:
+                raise ValueError(f"{name} must be between 0 and 1")
+        if self.max_gap_frames < 0:
+            raise ValueError("max_gap_frames cannot be negative")
+
+
+class PoseDetector(Protocol):
+    def detect(self, rgb_frame: np.ndarray, timestamp_ms: int = 0) -> tuple[Sequence[object], Sequence[object] | None] | None: ...
+    def close(self) -> None: ...
+
+
+class MediaPipePoseDetector:
+    """Lazy MediaPipe adapter so importing workflows does not initialize a model."""
+
+    def __init__(
+        self,
+        min_detection_confidence: float = 0.5,
+        min_tracking_confidence: float = 0.5,
+        model_path: str | None = None,
+    ):
+        try:
+            import mediapipe as mp
+        except ImportError as exc:
+            raise RuntimeError(
+                "MediaPipe Pose is unavailable. Install the Motion extension dependencies."
+            ) from exc
+        self._mp = mp
+        self._uses_tasks = not hasattr(mp, "solutions")
+        if not self._uses_tasks:
+            self._pose = mp.solutions.pose.Pose(
+                static_image_mode=False,
+                model_complexity=1,
+                smooth_landmarks=False,
+                enable_segmentation=False,
+                min_detection_confidence=min_detection_confidence,
+                min_tracking_confidence=min_tracking_confidence,
+            )
+        else:
+            asset = _ensure_pose_model(model_path)
+            options = mp.tasks.vision.PoseLandmarkerOptions(
+                base_options=mp.tasks.BaseOptions(model_asset_path=asset),
+                running_mode=mp.tasks.vision.RunningMode.VIDEO,
+                num_poses=1,
+                min_pose_detection_confidence=min_detection_confidence,
+                min_pose_presence_confidence=min_detection_confidence,
+                min_tracking_confidence=min_tracking_confidence,
+                output_segmentation_masks=False,
+            )
+            self._pose = mp.tasks.vision.PoseLandmarker.create_from_options(options)
+
+    def detect(self, rgb_frame: np.ndarray, timestamp_ms: int = 0):
+        if self._uses_tasks:
+            image = self._mp.Image(
+                image_format=self._mp.ImageFormat.SRGB,
+                data=np.ascontiguousarray(rgb_frame),
+            )
+            result = self._pose.detect_for_video(image, timestamp_ms)
+            if not result.pose_landmarks:
+                return None
+            world = result.pose_world_landmarks[0] if result.pose_world_landmarks else None
+            return result.pose_landmarks[0], world
+        result = self._pose.process(rgb_frame)
+        if result.pose_landmarks is None:
+            return None
+        world = result.pose_world_landmarks.landmark if result.pose_world_landmarks else None
+        return result.pose_landmarks.landmark, world
+
+    def close(self):
+        self._pose.close()
+
+
+def _ensure_pose_model(model_path: str | None) -> str:
+    if model_path:
+        path = Path(model_path).expanduser()
+        if not path.is_file():
+            raise FileNotFoundError(f"Pose model not found: {path}")
+        return str(path)
+
+    cache_root = Path(os.environ.get("SSUI_MODEL_CACHE", Path.home() / ".cache" / "ssui"))
+    path = cache_root / "mediapipe" / "pose_landmarker_full.task"
+    if path.is_file() and path.stat().st_size > 0:
+        return str(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(".download")
+    try:
+        with urlopen(POSE_MODEL_URL, timeout=60) as response, temporary.open("wb") as output:
+            while chunk := response.read(1024 * 1024):
+                output.write(chunk)
+        if temporary.stat().st_size == 0:
+            raise RuntimeError("Downloaded pose model is empty")
+        os.replace(temporary, path)
+    except (OSError, URLError) as exc:
+        temporary.unlink(missing_ok=True)
+        raise RuntimeError(
+            "Unable to download the MediaPipe pose model. Set PoseRecognitionOptions.model_path "
+            "to a local pose_landmarker .task file, or set SSUI_MODEL_CACHE to a writable cache."
+        ) from exc
+    return str(path)
+
+
+def _read_frames(video: Video):
+    if video.frames is not None:
+        frames = [frame.convert("RGB") for frame in video.frames]
+        if not frames:
+            raise ValueError("Video contains no frames")
+        yield from ((i, frame, float(video.fps or 30)) for i, frame in enumerate(frames))
+        return
+    if not video.path:
+        raise ValueError("Video needs either a file path or in-memory frames")
+
+    import cv2
+
+    capture = cv2.VideoCapture(video.path)
+    if not capture.isOpened():
+        raise ValueError(f"Cannot open video: {video.path}")
+    fps = float(capture.get(cv2.CAP_PROP_FPS) or video.fps or 30)
+    index = 0
+    try:
+        while True:
+            ok, bgr = capture.read()
+            if not ok:
+                break
+            rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+            yield index, PILImage.fromarray(rgb), fps
+            index += 1
+    finally:
+        capture.release()
+
+
+def _landmarks(raw: Sequence[object], world: Sequence[object] | None) -> list[PoseLandmark]:
+    result = []
+    for index, point in enumerate(raw):
+        world_point = world[index] if world is not None and index < len(world) else None
+        result.append(PoseLandmark(
+            name=LANDMARK_NAMES[index] if index < len(LANDMARK_NAMES) else f"landmark_{index}",
+            x=float(point.x), y=float(point.y), z=float(point.z),
+            visibility=float(getattr(point, "visibility", 0.0)),
+            presence=float(getattr(point, "presence", 0.0)),
+            world_x=float(world_point.x) if world_point is not None else None,
+            world_y=float(world_point.y) if world_point is not None else None,
+            world_z=float(world_point.z) if world_point is not None else None,
+        ))
+    return result
+
+
+def _blend(previous: list[PoseLandmark], current: list[PoseLandmark], smoothing: float) -> list[PoseLandmark]:
+    if len(previous) != len(current) or smoothing <= 0:
+        return current
+    keep = smoothing
+    fresh = 1 - keep
+    blended = []
+    for old, new in zip(previous, current):
+        values = {}
+        for axis in ("x", "y", "z", "world_x", "world_y", "world_z"):
+            a, b = getattr(old, axis), getattr(new, axis)
+            values[axis] = b if a is None or b is None else a * keep + b * fresh
+        blended.append(PoseLandmark(
+            name=new.name, visibility=new.visibility, presence=new.presence, **values
+        ))
+    return blended
+
+
+def _draw_pose(image: PILImage.Image, landmarks: list[PoseLandmark], confidence: float) -> PILImage.Image:
+    canvas = image.copy()
+    draw = ImageDraw.Draw(canvas, "RGBA")
+    width, height = canvas.size
+    for a, b in POSE_CONNECTIONS:
+        if a >= len(landmarks) or b >= len(landmarks):
+            continue
+        pa, pb = landmarks[a], landmarks[b]
+        if min(pa.visibility, pb.visibility) < confidence:
+            continue
+        draw.line((pa.x * width, pa.y * height, pb.x * width, pb.y * height), fill=(63, 224, 208, 225), width=max(2, width // 320))
+    radius = max(2, width // 240)
+    for point in landmarks:
+        if point.visibility < confidence:
+            continue
+        x, y = point.x * width, point.y * height
+        draw.ellipse((x - radius, y - radius, x + radius, y + radius), fill=(255, 190, 74, 255))
+    return canvas
+
+
+def recognize_pose(
+    video: Video,
+    options: PoseRecognitionOptions | None = None,
+    detector: PoseDetector | None = None,
+) -> tuple[Video, SkeletonAnimation]:
+    """Recognize a single person's pose and return overlay video plus animation data."""
+
+    options = options or PoseRecognitionOptions()
+    owns_detector = detector is None
+    detector = detector or MediaPipePoseDetector(
+        options.min_detection_confidence, options.min_tracking_confidence, options.model_path
+    )
+    pose_frames: list[PoseFrame] = []
+    overlay_frames: list[PILImage.Image] = []
+    previous: list[PoseLandmark] = []
+    missed = 0
+    source_fps = float(video.fps or 30)
+    output_fps = options.sample_fps or source_fps
+    width = height = 0
+    next_sample_time = 0.0
+    try:
+        for frame_index, image, actual_fps in _read_frames(video):
+            source_fps = actual_fps
+            output_fps = options.sample_fps or actual_fps
+            timestamp = frame_index / actual_fps
+            if options.sample_fps:
+                if timestamp + 1e-9 < next_sample_time:
+                    continue
+                next_sample_time += 1.0 / options.sample_fps
+            width, height = image.size
+            found = detector.detect(np.asarray(image), round(timestamp * 1000))
+            detected = found is not None
+            if found is not None:
+                current = _blend(previous, _landmarks(*found), options.smoothing)
+                previous, missed = current, 0
+            elif previous and missed < options.max_gap_frames:
+                missed += 1
+                current = [PoseLandmark(**{**point.__dict__, "visibility": point.visibility * (0.65 ** missed)}) for point in previous]
+            else:
+                missed += 1
+                current = []
+            pose_frames.append(PoseFrame(frame_index, timestamp, current, detected))
+            overlay_frames.append(_draw_pose(image, current, options.draw_confidence))
+    finally:
+        if owns_detector:
+            detector.close()
+
+    animation = SkeletonAnimation(
+        frames=pose_frames, fps=output_fps, width=width, height=height,
+        source=video.path,
+        metadata={"source_fps": source_fps, "sample_fps": output_fps, "landmark_count": len(LANDMARK_NAMES)},
+    )
+    return Video("mp4", overlay_frames, output_fps), animation

--- a/frontend/ssui_components/jest.config.js
+++ b/frontend/ssui_components/jest.config.js
@@ -6,6 +6,7 @@ export default {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
     '\\.module\\.css$': '<rootDir>/test/styleMock.js',
+    '\\.css$': '<rootDir>/test/styleMock.js',
   },
   transform: {
     '^.+\\.tsx?$': [

--- a/frontend/ssui_components/src/components/InternalComponents.ts
+++ b/frontend/ssui_components/src/components/InternalComponents.ts
@@ -1,6 +1,7 @@
 import './Image/ImageUploader';
 import './Image/ImagePicker';
 import './Video/VideoUploader';
+import './Motion/SkeletonPreview';
 import './Loader/SDLoader';
 import './Loader/ControlNetLoader';
 import './Base/ListContainer';

--- a/frontend/ssui_components/src/components/Motion/SkeletonPreview.css
+++ b/frontend/ssui_components/src/components/Motion/SkeletonPreview.css
@@ -1,0 +1,33 @@
+.motion-inspector {
+    --motion-ink: #e9f2f4;
+    --motion-panel: #12232c;
+    --motion-grid: #29414b;
+    --motion-cyan: #40dfd1;
+    --motion-amber: #ffbe4a;
+    min-width: 280px;
+    color: var(--motion-ink);
+    background: var(--motion-panel);
+    border: 1px solid #35505b;
+    border-radius: 6px;
+    overflow: hidden;
+    font-family: "Segoe UI", sans-serif;
+}
+.motion-header, .motion-meta { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.motion-header { padding: 11px 13px; border-bottom: 1px solid var(--motion-grid); }
+.motion-header strong { display: block; margin-top: 2px; font-size: 14px; letter-spacing: .02em; }
+.motion-kicker, .motion-meta, .frame-stamp { font: 10px/1.2 Consolas, monospace; letter-spacing: .08em; color: #91a9b2; }
+.tracking { padding: 4px 7px; border: 1px solid #566a72; border-radius: 10px; font-size: 10px; color: #a5b4ba; }
+.tracking.live { border-color: #258a82; color: var(--motion-cyan); }
+.stage-shell { position: relative; aspect-ratio: 16/10; background-color: #0a171d; background-image: linear-gradient(#17303980 1px, transparent 1px), linear-gradient(90deg, #17303980 1px, transparent 1px); background-size: 20px 20px; }
+.skeleton-stage { width: 100%; height: 100%; }
+.skeleton-bone { stroke: var(--motion-cyan); stroke-width: .75; vector-effect: non-scaling-stroke; filter: url(#joint-glow); }
+.skeleton-joint { fill: var(--motion-amber); filter: url(#joint-glow); }
+.frame-stamp { position: absolute; right: 9px; bottom: 7px; }
+.motion-timeline { display: block; width: calc(100% - 24px); margin: 10px 12px 5px; accent-color: var(--motion-amber); }
+.motion-meta { padding: 4px 12px 11px; }
+.motion-meta a { color: var(--motion-cyan); text-decoration: none; }
+.motion-exports { display: inline-flex; gap: 8px; }
+.motion-meta a:focus-visible { outline: 2px solid var(--motion-amber); outline-offset: 2px; }
+.motion-empty, .motion-error { padding: 28px 16px; text-align: center; font-size: 12px; color: #9eb1b8; }
+.motion-error { color: #ff9c8b; }
+@media (prefers-reduced-motion: reduce) { .motion-inspector * { scroll-behavior: auto !important; } }

--- a/frontend/ssui_components/src/components/Motion/SkeletonPreview.tsx
+++ b/frontend/ssui_components/src/components/Motion/SkeletonPreview.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { registerComponent, ComponentRegister } from '../ComponentsManager';
+import { IComponent } from '../IComponent';
+import './SkeletonPreview.css';
+
+type Landmark = { name: string; x: number; y: number; z: number; visibility: number };
+type PoseFrame = { frame_index: number; timestamp: number; landmarks: Landmark[]; detected: boolean };
+type AnimationData = { frames: PoseFrame[]; fps: number; width: number; height: number; model: string };
+type State = { data?: AnimationData; index: number; loading: boolean; error?: string; path?: string; bvhPath?: string; retargetPath?: string; retargetRmse?: number };
+
+const connections = [
+    [0,2],[2,5],[5,0],[2,7],[5,8],[11,12],[11,13],[13,15],[12,14],[14,16],
+    [11,23],[12,24],[23,24],[23,25],[25,27],[27,31],[24,26],[26,28],[28,32],
+];
+
+export class SkeletonPreview extends IComponent<{}, State> {
+    state: State = { index: 0, loading: false };
+
+    override async onUpdate(payload: { path?: string; bvh_path?: string; retarget_path?: string; retarget_rmse?: number }): Promise<void> {
+        if (!payload?.path) {
+            this.setState({ error: '识别结果没有数据文件。' });
+            return;
+        }
+        this.setState({ loading: true, error: undefined, path: payload.path, bvhPath: payload.bvh_path, retargetPath: payload.retarget_path, retargetRmse: payload.retarget_rmse });
+        try {
+            const response = await fetch('/file?path=' + encodeURIComponent(payload.path));
+            if (!response.ok) throw new Error(`读取失败 (${response.status})`);
+            const data = await response.json() as AnimationData;
+            this.setState({ data, index: 0, loading: false });
+        } catch (error) {
+            this.setState({ loading: false, error: error instanceof Error ? error.message : '无法读取骨骼数据。' });
+        }
+    }
+
+    private renderSkeleton(frame?: PoseFrame) {
+        const points = frame?.landmarks ?? [];
+        return (
+            <svg className="skeleton-stage" viewBox="0 0 100 100" role="img" aria-label="当前帧骨骼">
+                <defs><filter id="joint-glow"><feGaussianBlur stdDeviation="0.75" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter></defs>
+                {connections.map(([a,b], i) => points[a] && points[b] && Math.min(points[a].visibility, points[b].visibility) > .3 ?
+                    <line key={i} x1={points[a].x*100} y1={points[a].y*100} x2={points[b].x*100} y2={points[b].y*100} className="skeleton-bone"/> : null)}
+                {points.map((point, i) => point.visibility > .3 ?
+                    <circle key={i} cx={point.x*100} cy={point.y*100} r="1.05" className="skeleton-joint"/> : null)}
+            </svg>
+        );
+    }
+
+    override render() {
+        const { data, index, loading, error, path, bvhPath, retargetPath, retargetRmse } = this.state;
+        const frame = data?.frames[index];
+        return <section className="motion-inspector">
+            <header className="motion-header">
+                <div><span className="motion-kicker">MOTION / POSE 33</span><strong>骨骼动画</strong></div>
+                {data && <span className={frame?.detected ? 'tracking live' : 'tracking'}>{frame?.detected ? '已锁定' : '推算帧'}</span>}
+            </header>
+            {loading && <div className="motion-empty">正在载入动作轨迹…</div>}
+            {error && <div className="motion-error">{error}</div>}
+            {!loading && !error && !data && <div className="motion-empty">运行骨骼识别后，在这里逐帧检查动作。</div>}
+            {data && <>
+                <div className="stage-shell">{this.renderSkeleton(frame)}<span className="frame-stamp">{frame?.timestamp.toFixed(2)}s</span></div>
+                <input className="motion-timeline" aria-label="动画帧" type="range" min="0" max={Math.max(0, data.frames.length-1)} value={index}
+                    onChange={event => this.setState({ index: Number(event.target.value) })}/>
+                <footer className="motion-meta">
+                    <span>{index + 1} / {data.frames.length} 帧</span><span>{data.fps.toFixed(1)} FPS</span>
+                    {typeof retargetRmse === 'number' && <span title="固定骨长 BVH 与识别关键点之间的均方根误差">误差 {retargetRmse.toFixed(3)}</span>}
+                    <span className="motion-exports">
+                        {path && <a href={'/file?path=' + encodeURIComponent(path)} download>JSON</a>}
+                        {bvhPath && <a href={'/file?path=' + encodeURIComponent(bvhPath)} download>BVH</a>}
+                        {retargetPath && <a href={'/file?path=' + encodeURIComponent(retargetPath)} download>报告</a>}
+                    </span>
+                </footer>
+            </>}
+        </section>;
+    }
+}
+
+registerComponent({
+    name: 'SkeletonPreview', type: 'ssui.base.SkeletonAnimation', port: 'output', component: SkeletonPreview,
+} as ComponentRegister);

--- a/frontend/ssui_components/src/components/Video/VideoUploader.tsx
+++ b/frontend/ssui_components/src/components/Video/VideoUploader.tsx
@@ -53,7 +53,7 @@ const VideoUploader = forwardRef((props: VideoUploaderProps, ref) => {
     const preview = () => {
         if (video) {
             return <div>
-                <img src={'/file?path=' + video} alt="preview" style={{ maxWidth: '100%', height: 'auto' }} />
+                <video src={'/file?path=' + encodeURIComponent(video)} controls muted style={{ maxWidth: '100%', height: 'auto' }} />
             </div>
         }
     }
@@ -76,29 +76,49 @@ const VideoUploader = forwardRef((props: VideoUploaderProps, ref) => {
 
 const VideoPreview = forwardRef((props, ref) => {
     const [video, setVideo] = useState<string>('');
+    const [metadata, setMetadata] = useState<Record<string, string | number | null>>({});
 
     useImperativeHandle(ref, () => {
         return {
             onUpdate: (data: any) => {
                 console.log('VideoPreview onUpdate:', data);
                 setVideo(data.path);
+                setMetadata(data.metadata || {});
             }
         }
     }, []);
 
     return (
         <div>
-            {video != '' ? 
-                <img 
-                    src={'/file?path=' + video} 
-                    alt="placeholder" 
-                    style={{ 
-                        maxWidth: '100%', 
-                        height: 'auto', 
+            {video != '' ? <>
+                <video
+                    src={'/file?path=' + encodeURIComponent(video)}
+                    controls
+                    muted
+                    style={{
+                        maxWidth: '100%',
+                        height: 'auto',
                         display: 'block',
                         margin: '0 auto'
-                    }} 
-                /> : 
+                    }}
+                />
+                {metadata.kind === 'blender_comparison' && <div style={{ marginTop: 8, fontSize: 12 }}>
+                    <div>
+                        Blender {metadata.blender_version || 'unknown'}
+                        {typeof metadata.comparison_rmse === 'number' && ` · RMSE ${metadata.comparison_rmse.toFixed(6)}`}
+                    </div>
+                    <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginTop: 4 }}>
+                        {['scene_path', 'report_path', 'bvh_path', 'retarget_path'].map(key => {
+                            const path = metadata[key];
+                            if (typeof path !== 'string' || !path) return null;
+                            const labels: Record<string, string> = {
+                                scene_path: 'BLEND', report_path: '报告', bvh_path: 'BVH', retarget_path: '重定向',
+                            };
+                            return <a key={key} href={'/file?path=' + encodeURIComponent(path)} download>{labels[key]}</a>;
+                        })}
+                    </div>
+                </div>}
+            </> :
                 <p>No video</p>
             }
         </div>

--- a/ss_executor/__main__.py
+++ b/ss_executor/__main__.py
@@ -7,6 +7,7 @@ import json
 from typing import Dict, Optional, Union
 import logging
 import sys
+import uuid
 
 project_root = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
@@ -22,7 +23,7 @@ for dir in os.listdir(extensions_root):
 
 
 from ss_executor.loader import SSLoader, search_project_root
-from ssui.base import Image
+from ssui.base import Image, SkeletonAnimation, Video
 from ss_executor.sandbox import Sandbox
 from ss_executor.model import KillMessage, TaskStatus, Task, ExecutorRegister, RegisterResponse, UpdateStatus, TaskResult, ExeMessage
 import traceback
@@ -166,6 +167,58 @@ class Executor:
                         path = os.path.join(output_dir, "image_" + current_time.strftime("%Y%m%d%H%M%S") + ".png")
                         result._image.save(path)
                         return {"type": "image", "path": path}
+                    if isinstance(result, Video):
+                        if result.path and not result.frames:
+                            return {"type": "video", "path": result.path, "metadata": result.metadata}
+                        if not result.frames:
+                            raise ValueError("Video result contains neither a path nor frames")
+                        import cv2
+                        import numpy as np
+                        project_root = search_project_root(os.path.dirname(task.script))
+                        output_dir = os.path.join(project_root, "output")
+                        os.makedirs(output_dir, exist_ok=True)
+                        path = os.path.join(output_dir, f"video_{uuid.uuid4().hex}.mp4")
+                        width, height = result.frames[0].size
+                        writer = cv2.VideoWriter(
+                            path, cv2.VideoWriter_fourcc(*"mp4v"), float(result.fps), (width, height)
+                        )
+                        if not writer.isOpened():
+                            raise RuntimeError("Unable to create the pose preview video")
+                        try:
+                            for frame in result.frames:
+                                rgb = np.asarray(frame.convert("RGB"))
+                                writer.write(cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR))
+                        finally:
+                            writer.release()
+                        return {
+                            "type": "video", "path": path, "fps": result.fps,
+                            "metadata": result.metadata,
+                        }
+                    if isinstance(result, SkeletonAnimation):
+                        from ssui_motion import export_bvh
+                        project_root = search_project_root(os.path.dirname(task.script))
+                        output_dir = os.path.join(project_root, "output")
+                        os.makedirs(output_dir, exist_ok=True)
+                        stem = os.path.join(output_dir, f"skeleton_{uuid.uuid4().hex}")
+                        path = stem + ".json"
+                        with open(path, "w", encoding="utf-8") as output:
+                            json.dump(result.to_dict(), output, ensure_ascii=False, indent=2)
+                        payload = {
+                            "type": "skeleton_animation", "path": path,
+                            "frames": len(result.frames), "duration": result.duration,
+                            "fps": result.fps,
+                        }
+                        try:
+                            bvh_path = stem + ".bvh"
+                            bvh = export_bvh(result, bvh_path)
+                            payload.update({
+                                "bvh_path": bvh_path,
+                                "retarget_path": stem + ".retarget.json",
+                                "retarget_rmse": bvh.report["rmse"],
+                            })
+                        except ValueError as export_error:
+                            payload["retarget_error"] = str(export_error)
+                        return payload
                 # 注入配置
                 loader.config._update = task.details
                 # 执行

--- a/ss_executor/sandbox.py
+++ b/ss_executor/sandbox.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from ss_executor.loader import ModuleExecutor
 
 allowed_modules = set([
-    'ssui', 'ssui_image', 'ssui_video', 'ssui_audio', 'ssui_voice', 'ssui_3dmodel', 
+    'ssui', 'ssui_image', 'ssui_video', 'ssui_audio', 'ssui_voice', 'ssui_3dmodel', 'ssui_motion',
     'stdgen', 'trellis', 'cosyvoice', 'typing'])
 
 @dataclass

--- a/ssui/__init__.py
+++ b/ssui/__init__.py
@@ -5,7 +5,7 @@
 """
 
 from .annotation import workflow
-from .base import Image, Mesh, Noise, Prompt, Video, Voice
+from .base import Image, Mesh, Noise, PoseFrame, PoseLandmark, Prompt, SkeletonAnimation, Video, Voice
 from .config import SSUIConfig
 from .controller import Input, Random, Select, Slider, Switch
 
@@ -16,6 +16,9 @@ __all__ = [
     "Noise",
     "Prompt",
     "Video",
+    "PoseLandmark",
+    "PoseFrame",
+    "SkeletonAnimation",
     "Voice",
     "SSUIConfig",
     "Input",

--- a/ssui/base.py
+++ b/ssui/base.py
@@ -1,5 +1,7 @@
 import PIL.Image
 import trimesh
+from dataclasses import asdict, dataclass, field
+from typing import Any
 
 class Image():
     def __init__(self, image: PIL.Image.Image = None):
@@ -15,10 +17,79 @@ class Mesh():
         self._model = model
 
 class Video():
-    def __init__(self, format: str, frames: list[PIL.Image.Image] = None, fps: int = 30):
+    def __init__(self, format: str = "mp4", frames: list[PIL.Image.Image] = None, fps: float = 30, video: str = None, path: str = None, metadata: dict[str, Any] = None):
         self._format = format
         self._frames = frames
         self._fps = fps
+        # Upload components historically send {"video": path}; ``path`` is the
+        # clearer spelling for programmatic callers.  Keep both compatible.
+        self._path = path or video
+        self._metadata = metadata or {}
+
+    @property
+    def path(self):
+        return self._path
+
+    @property
+    def frames(self):
+        return self._frames
+
+    @property
+    def fps(self):
+        return self._fps
+
+    @property
+    def metadata(self):
+        return self._metadata
+
+
+@dataclass
+class PoseLandmark:
+    """One normalized body landmark.
+
+    x/y are normalized image coordinates. z is MediaPipe's relative depth;
+    world_x/y/z are metric model-space coordinates when the detector provides
+    them.
+    """
+
+    name: str
+    x: float
+    y: float
+    z: float = 0.0
+    visibility: float = 0.0
+    presence: float = 0.0
+    world_x: float | None = None
+    world_y: float | None = None
+    world_z: float | None = None
+
+
+@dataclass
+class PoseFrame:
+    frame_index: int
+    timestamp: float
+    landmarks: list[PoseLandmark] = field(default_factory=list)
+    detected: bool = True
+
+
+@dataclass
+class SkeletonAnimation:
+    """Time-indexed pose data suitable for preview, editing, and retargeting."""
+
+    frames: list[PoseFrame] = field(default_factory=list)
+    fps: float = 30.0
+    width: int = 0
+    height: int = 0
+    source: str | None = None
+    model: str = "mediapipe-pose-33"
+    coordinate_system: str = "image-normalized+x-right+y-down; world+x-right+y-up"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def duration(self) -> float:
+        return self.frames[-1].timestamp if self.frames else 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
 
 class Audio():
     def __init__(self, format: str, audio: bytes = None, fps: int = 16000):

--- a/tests/motion_bvh_test.py
+++ b/tests/motion_bvh_test.py
@@ -1,0 +1,64 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from ssui import PoseFrame, PoseLandmark, SkeletonAnimation
+from ssui_motion import export_bvh, to_bvh
+
+
+POSITIONS = {
+    "nose": (0, 1.75, 0), "left_shoulder": (-0.2, 1.45, 0), "right_shoulder": (0.2, 1.45, 0),
+    "left_elbow": (-0.5, 1.35, 0), "right_elbow": (0.5, 1.35, 0),
+    "left_wrist": (-0.75, 1.25, 0), "right_wrist": (0.75, 1.25, 0),
+    "left_index": (-0.82, 1.22, 0), "right_index": (0.82, 1.22, 0),
+    "left_hip": (-0.14, 0.95, 0), "right_hip": (0.14, 0.95, 0),
+    "left_knee": (-0.14, 0.52, 0), "right_knee": (0.14, 0.52, 0),
+    "left_ankle": (-0.14, 0.08, 0), "right_ankle": (0.14, 0.08, 0),
+    "left_foot_index": (-0.14, 0.02, -0.18), "right_foot_index": (0.14, 0.02, -0.18),
+}
+
+
+def animation():
+    frames = []
+    for frame_index, shift in enumerate((0.0, 0.03, 0.06)):
+        positions = dict(POSITIONS)
+        if frame_index == 1:
+            positions.update({
+                "left_elbow": (-0.424, 1.674, 0), "left_wrist": (-0.524, 1.924, 0), "left_index": (-0.594, 1.954, 0),
+                "right_knee": (0.14, 0.60, -0.25), "right_ankle": (0.14, 0.24, -0.50), "right_foot_index": (0.14, 0.18, -0.68),
+            })
+        elif frame_index == 2:
+            positions.update({
+                "right_elbow": (0.424, 1.674, 0), "right_wrist": (0.524, 1.924, 0), "right_index": (0.594, 1.954, 0),
+                "left_knee": (-0.14, 0.60, -0.25), "left_ankle": (-0.14, 0.24, -0.50), "left_foot_index": (-0.14, 0.18, -0.68),
+            })
+        landmarks = [
+            PoseLandmark(name, 0.5 + x / 2 + shift, 1 - y / 2, z, 1, 1, x, y, z)
+            for name, (x, y, z) in positions.items()
+        ]
+        frames.append(PoseFrame(frame_index, frame_index / 30, landmarks))
+    return SkeletonAnimation(frames=frames, fps=30, width=1920, height=1080)
+
+
+class MotionBVHTest(unittest.TestCase):
+    def test_bvh_has_hierarchy_motion_and_finite_report(self):
+        result = to_bvh(animation())
+        self.assertIn("ROOT Hips", result.content)
+        self.assertIn("JOINT LeftForeArm", result.content)
+        self.assertIn("Frames: 3", result.content)
+        motion_rows = result.content.split("Frame Time:", 1)[1].strip().splitlines()[1:]
+        self.assertEqual(len(motion_rows), 3)
+        self.assertTrue(all(len(row.split()) == 66 for row in motion_rows))
+        self.assertGreaterEqual(result.report["rmse"], 0)
+        self.assertEqual(len(result.report["target"]), 3)
+
+    def test_export_writes_bvh_and_comparison_payload(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "walk.bvh"
+            result = export_bvh(animation(), path)
+            self.assertEqual(path.read_text(encoding="utf-8"), result.content)
+            self.assertTrue(path.with_suffix(".retarget.json").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/motion_nodes_test.py
+++ b/tests/motion_nodes_test.py
@@ -1,0 +1,70 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from PIL import Image
+
+from ssui import SkeletonAnimation, Video
+from ssui.config import SSUIConfig
+from ssui_motion import RecognizePose, RenderBlenderComparison, render_blender_comparison
+from tests.motion_bvh_test import animation
+
+
+class MotionNodesTest(unittest.TestCase):
+    def test_prepare_registers_pose_controls_without_running_detector(self):
+        config = SSUIConfig()
+        config.set_prepared()
+
+        overlay, skeleton = RecognizePose(config("Pose Recognition"), None)
+
+        self.assertIsInstance(overlay, Video)
+        self.assertIsInstance(skeleton, SkeletonAnimation)
+        self.assertEqual(
+            set(config._config["Pose Recognition"]),
+            {
+                "sample_fps", "smoothing", "detection_confidence",
+                "tracking_confidence", "max_gap_frames", "model_path",
+            },
+        )
+
+    def test_prepare_registers_blender_control_without_launching_blender(self):
+        config = SSUIConfig()
+        config.set_prepared()
+
+        result = RenderBlenderComparison(config("Blender Comparison"), None)
+
+        self.assertIsInstance(result, Video)
+        self.assertIn("blender_executable", config._config["Blender Comparison"])
+
+    def test_blender_result_uses_video_port_and_preserves_artifact_metadata(self):
+        def fake_blender(arguments, _explicit):
+            root = Path(arguments[arguments.index("--output-dir") + 1])
+            (root / "frames").mkdir(parents=True, exist_ok=True)
+            (root / "pose-comparison.blend").write_bytes(b"BLENDER")
+            (root / "blender-comparison.json").write_text(
+                json.dumps({
+                    "blender_version": "test", "rmse": 0.001,
+                    "max_error": 0.002,
+                }),
+                encoding="utf-8",
+            )
+            Image.new("RGB", (32, 32), "black").save(
+                root / "frames" / "pose-comparison-0001.png"
+            )
+
+        with tempfile.TemporaryDirectory() as directory, patch(
+            "ssui_motion.blender._run_blender", side_effect=fake_blender
+        ):
+            result = render_blender_comparison(animation(), directory)
+
+        self.assertIsInstance(result, Video)
+        self.assertEqual(len(result.frames), 1)
+        self.assertEqual(result.metadata["kind"], "blender_comparison")
+        self.assertEqual(result.metadata["comparison_rmse"], 0.001)
+        self.assertTrue(result.metadata["scene_path"].endswith("pose-comparison.blend"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/motion_pose_test.py
+++ b/tests/motion_pose_test.py
@@ -1,0 +1,67 @@
+import unittest
+from types import SimpleNamespace
+
+from PIL import Image
+
+from ssui import SkeletonAnimation, Video
+from ssui_motion import PoseRecognitionOptions, recognize_pose
+
+
+class FakeDetector:
+    def __init__(self, results):
+        self.results = iter(results)
+        self.closed = False
+
+    def detect(self, _frame, _timestamp_ms=0):
+        return next(self.results)
+
+    def close(self):
+        self.closed = True
+
+
+def points(offset=0.0):
+    image = [SimpleNamespace(x=0.2 + offset + i * 0.001, y=0.3, z=-0.1, visibility=0.9, presence=0.8) for i in range(33)]
+    world = [SimpleNamespace(x=0.01 * i, y=0.02 * i, z=0.03 * i) for i in range(33)]
+    return image, world
+
+
+class MotionPoseTest(unittest.TestCase):
+    def test_video_accepts_uploaded_path_shape(self):
+        video = Video(video="input/dance.mp4")
+        self.assertEqual(video.path, "input/dance.mp4")
+        self.assertEqual(video._format, "mp4")
+
+    def test_recognize_pose_returns_overlay_and_serializable_animation(self):
+        video = Video(frames=[Image.new("RGB", (160, 90)) for _ in range(3)], fps=30)
+        detector = FakeDetector([points(0), points(0.1), None])
+
+        overlay, animation = recognize_pose(
+            video,
+            PoseRecognitionOptions(smoothing=0.5, max_gap_frames=1),
+            detector,
+        )
+
+        self.assertEqual(len(overlay.frames), 3)
+        self.assertIsInstance(animation, SkeletonAnimation)
+        self.assertEqual((animation.width, animation.height), (160, 90))
+        self.assertEqual(len(animation.frames[0].landmarks), 33)
+        self.assertAlmostEqual(animation.frames[1].landmarks[0].x, 0.25)
+        self.assertFalse(animation.frames[2].detected)
+        self.assertLess(animation.frames[2].landmarks[0].visibility, 0.9)
+        self.assertEqual(animation.to_dict()["model"], "mediapipe-pose-33")
+
+    def test_sampling_uses_requested_timeline_rate(self):
+        video = Video(frames=[Image.new("RGB", (32, 32)) for _ in range(30)], fps=30)
+        detector = FakeDetector([points() for _ in range(10)])
+        _, animation = recognize_pose(video, PoseRecognitionOptions(sample_fps=10, smoothing=0), detector)
+        self.assertEqual(len(animation.frames), 10)
+        self.assertEqual([f.frame_index for f in animation.frames[:3]], [0, 3, 6])
+        self.assertEqual(animation.fps, 10)
+
+    def test_invalid_options_fail_early(self):
+        with self.assertRaises(ValueError):
+            PoseRecognitionOptions(smoothing=1.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add MediaPipe single-person pose recognition as configurable SSUI nodes
- export SkeletonAnimation data to BVH with retarget error reports
- run Blender reconstruction/comparison from standard or Microsoft Store installations
- add skeleton and Blender artifact previews to the component system
- provide a video-to-Blender example workflow, CLI helpers, documentation, and focused tests

## Validation
- `npx --yes yarn@1.22.22 build:components`
- `npx --yes yarn@1.22.22 workspace ssui_components jest test/CoreComponents.test.ts test/ComponentsManager.test.ts test/ControlNetLoader.test.ts --runInBand` (8 tests)
- `python -m unittest tests.motion_pose_test tests.motion_bvh_test tests.motion_nodes_test` in an isolated dependency target (9 tests)
- `git diff --check origin/dev...HEAD`
- Blender 5.2.1 LTS MSIX background import/render validation: 3 frames, 63 joint samples, RMSE 0.0004367, max error 0.0015917 Blender units

## Known local limitation
- the full component Jest command also starts `Message.test.ts`, which requires `.venv/Scripts/fastapi`; this worktree does not have the project Python venv. The three non-service component suites pass.