### PR TITLE
feat: add Kimodo motion generation for Windows AMDGPU

### DIFF
--- a/examples/advance/workflow-motion.py
+++ b/examples/advance/workflow-motion.py
@@ -1,0 +1,12 @@
+from ssui import Prompt, workflow
+from ssui.config import SSUIConfig
+from ssui_motion.Kimodo import KimodoTextToMotion
+
+
+config = SSUIConfig()
+
+
+@workflow
+def txt2motion_kimodo(prompt: Prompt) -> str:
+    """Generate 3D human or robot motion with NVIDIA Kimodo on Windows AMDGPU."""
+    return KimodoTextToMotion(config("Kimodo Text To Motion"), prompt)

--- a/extensions/Motion/README.md
+++ b/extensions/Motion/README.md
@@ -1,0 +1,73 @@
+# Motion extension
+
+The Motion extension runs NVIDIA Kimodo in an isolated child environment. This
+keeps Kimodo's pinned `transformers==5.1.0` dependency from replacing the
+versions used by SSUI's Image and Video extensions, while reusing the project's
+ROCm-enabled PyTorch installation.
+
+## Windows AMDGPU setup
+
+From the repository root, after the normal `yarn` installation:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File extensions/Motion/install_kimodo.ps1
+```
+
+The installer creates `.venv/kimodo`, installs the official Kimodo source at a
+pinned commit, and reuses `.venv/Lib/site-packages` for PyTorch/ROCm. It skips
+the optional native `motion_correction` postprocessor; text-to-motion generation
+and NPZ/BVH export remain available.
+
+Kimodo's text encoder uses the gated
+`meta-llama/Meta-Llama-3-8B-Instruct` model. Request access on Hugging Face, then
+authenticate inside the child environment:
+
+```powershell
+.venv\kimodo\Scripts\hf.exe auth login
+```
+
+If Meta access is still pending, a compatible community snapshot may be used
+temporarily by setting `SSUI_KIMODO_TEXT_ENCODER_BASE` to its downloaded local
+snapshot directory. The tested fallback is
+`raducius/Llama-3-8B-Instruct-LLM2Vec-mntp-merged` at revision
+`01417d622e8a85d6f4b308dac0e37d478a9a87d1`. It is a community artifact under
+the Llama 3 license, not an NVIDIA-supported Kimodo dependency. Unset the
+variable to return to the official gated encoder.
+
+Generated files are written under the project `output/` directory. Set
+`SSUI_KIMODO_PYTHON` to use a different Kimodo interpreter. For cards with less
+than 16 GB VRAM, select `cpu` for `text_encoder_device`; the Kimodo denoiser will
+still run on the GPU.
+
+The bundled node exposes the SOMA and Unitree G1 checkpoints. SMPL-X needs the
+additional upstream SMPL-X/SOMA setup and is intentionally not offered by the
+default Windows installer.
+
+## Workflow node
+
+```python
+from ssui import Prompt
+from ssui.config import SSUIConfig
+from ssui_motion.Kimodo import KimodoTextToMotion
+
+config = SSUIConfig()
+motion_path = KimodoTextToMotion(
+    config("Kimodo Text To Motion"),
+    Prompt("A person walks forward and waves."),
+)
+```
+
+## Blender preview
+
+The generated SOMA BVH can be turned into a rendered skeleton preview with the
+bundled Blender script:
+
+```powershell
+blender --background --factory-startup `
+  --python extensions/Motion/render_bvh_blender.py -- `
+  --input output/motion.bvh --output-dir output/blender_preview `
+  --ffmpeg path/to/ffmpeg
+```
+
+The script converts Kimodo's centimeter BVH units to meters and produces a PNG
+preview, an H.264 MP4 animation, and an editable `.blend` scene.

--- a/extensions/Motion/extension.py
+++ b/extensions/Motion/extension.py
@@ -1,0 +1,4 @@
+from fastapi import APIRouter
+
+
+app = APIRouter()

--- a/extensions/Motion/install_kimodo.ps1
+++ b/extensions/Motion/install_kimodo.ps1
@@ -1,0 +1,27 @@
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$ProjectPython = Join-Path $RepoRoot ".venv\Scripts\python.exe"
+$KimodoRoot = Join-Path $RepoRoot ".venv\kimodo"
+$KimodoPython = Join-Path $KimodoRoot "Scripts\python.exe"
+$ParentSitePackages = Join-Path $RepoRoot ".venv\Lib\site-packages"
+$PthFile = Join-Path $KimodoRoot "Lib\site-packages\ssui_parent_venv.pth"
+$KimodoCommit = "1aece8c124d73d255ceff5086d983b844c9f4e94"
+
+if (-not (Test-Path -LiteralPath $ProjectPython)) {
+    throw "Project venv is missing. Run yarn at the repository root first."
+}
+
+if (-not (Test-Path -LiteralPath $KimodoPython)) {
+    & $ProjectPython -m venv $KimodoRoot
+}
+
+# Reuse the project's verified ROCm PyTorch without upgrading the shared SSUI
+# environment. Packages installed in the child environment take precedence.
+Set-Content -LiteralPath $PthFile -Value $ParentSitePackages -Encoding utf8
+
+$env:SKIP_MOTION_CORRECTION_IN_SETUP = "1"
+& $KimodoPython -m pip install --timeout 300 `
+    "kimodo @ git+https://github.com/nv-tlabs/kimodo.git@$KimodoCommit"
+
+& $KimodoPython -c "import kimodo, torch, transformers; print('kimodo:', kimodo.__file__); print('torch:', torch.__version__); print('transformers:', transformers.__version__); print('gpu:', torch.cuda.get_device_name(0) if torch.cuda.is_available() else 'unavailable')"

--- a/extensions/Motion/render_bvh_blender.py
+++ b/extensions/Motion/render_bvh_blender.py
@@ -1,0 +1,272 @@
+"""Render a Kimodo BVH as a polished skeleton preview in Blender."""
+
+import argparse
+import math
+import os
+import subprocess
+import sys
+
+import bpy
+from mathutils import Vector
+
+
+def parse_args():
+    argv = sys.argv[sys.argv.index("--") + 1 :] if "--" in sys.argv else []
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--name", default="kimodo_motion")
+    parser.add_argument("--ffmpeg")
+    return parser.parse_args(argv)
+
+
+def material(name, color, metallic=0.0, roughness=0.4, emission=0.0):
+    mat = bpy.data.materials.new(name)
+    mat.diffuse_color = (*color, 1.0)
+    mat.use_nodes = True
+    shader = mat.node_tree.nodes.get("Principled BSDF")
+    shader.inputs["Base Color"].default_value = (*color, 1.0)
+    shader.inputs["Metallic"].default_value = metallic
+    shader.inputs["Roughness"].default_value = roughness
+    if emission:
+        emission_input = shader.inputs.get("Emission Color") or shader.inputs.get("Emission")
+        if emission_input:
+            emission_input.default_value = (*color, 1.0)
+        shader.inputs["Emission Strength"].default_value = emission
+    return mat
+
+
+def shared_meshes():
+    bpy.ops.mesh.primitive_ico_sphere_add(subdivisions=2, radius=1.0)
+    sphere = bpy.context.object
+    sphere_mesh = sphere.data.copy()
+    bpy.data.objects.remove(sphere, do_unlink=True)
+
+    bpy.ops.mesh.primitive_cylinder_add(vertices=12, radius=1.0, depth=2.0)
+    cylinder = bpy.context.object
+    cylinder_mesh = cylinder.data.copy()
+    bpy.data.objects.remove(cylinder, do_unlink=True)
+    return sphere_mesh, cylinder_mesh
+
+
+def look_at(obj, target):
+    obj.rotation_euler = (Vector(target) - obj.location).to_track_quat("-Z", "Y").to_euler()
+
+
+def add_area_light(name, location, energy, size, color, target):
+    light_data = bpy.data.lights.new(name, "AREA")
+    light_data.energy = energy
+    light_data.shape = "DISK"
+    light_data.size = size
+    light_data.color = color
+    light = bpy.data.objects.new(name, light_data)
+    bpy.context.collection.objects.link(light)
+    light.location = location
+    look_at(light, target)
+
+
+def create_trail(points, trail_material):
+    curve = bpy.data.curves.new("RootTrail", "CURVE")
+    curve.dimensions = "3D"
+    curve.resolution_u = 2
+    curve.bevel_depth = 0.012
+    curve.bevel_resolution = 3
+    spline = curve.splines.new("POLY")
+    spline.points.add(len(points) - 1)
+    for point, coordinate in zip(spline.points, points):
+        point.co = (*coordinate, 1.0)
+    obj = bpy.data.objects.new("Root Trail", curve)
+    bpy.context.collection.objects.link(obj)
+    obj.data.materials.append(trail_material)
+
+
+def main():
+    args = parse_args()
+    input_path = os.path.abspath(args.input)
+    output_dir = os.path.abspath(args.output_dir)
+    os.makedirs(output_dir, exist_ok=True)
+
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete(use_global=False)
+    bpy.ops.preferences.addon_enable(module="io_anim_bvh")
+    result = bpy.ops.import_anim.bvh(
+        filepath=input_path,
+        target="ARMATURE",
+        global_scale=0.01,
+        frame_start=1,
+        use_fps_scale=False,
+        update_scene_fps=True,
+        update_scene_duration=True,
+        rotate_mode="QUATERNION",
+        axis_forward="-Z",
+        axis_up="Y",
+    )
+    if "FINISHED" not in result:
+        raise RuntimeError(f"BVH import failed: {result}")
+
+    armature = next(obj for obj in bpy.context.scene.objects if obj.type == "ARMATURE")
+    armature.hide_render = True
+    scene = bpy.context.scene
+    action = armature.animation_data.action if armature.animation_data else None
+    if action:
+        scene.frame_start = max(1, math.floor(action.frame_range[0]))
+        scene.frame_end = max(scene.frame_start, math.ceil(action.frame_range[1]))
+    else:
+        scene.frame_start = 1
+    scene.render.fps = 30
+
+    frames = range(scene.frame_start, scene.frame_end + 1)
+    bone_names = [bone.name for bone in armature.pose.bones if bone.bone.length > 1e-5]
+    samples = {}
+    all_points = []
+    root_points = []
+    for frame in frames:
+        scene.frame_set(frame)
+        frame_samples = {}
+        for name in bone_names:
+            bone = armature.pose.bones[name]
+            head = armature.matrix_world @ bone.head
+            tail = armature.matrix_world @ bone.tail
+            frame_samples[name] = (head.copy(), tail.copy())
+            all_points.extend((head, tail))
+        samples[frame] = frame_samples
+        root_bone = armature.pose.bones.get("Hips") or armature.pose.bones[0]
+        root = armature.matrix_world @ root_bone.head
+        root_points.append(Vector((root.x, root.y, min(p.z for p in all_points) + 0.018)))
+
+    mins = Vector((min(p.x for p in all_points), min(p.y for p in all_points), min(p.z for p in all_points)))
+    maxs = Vector((max(p.x for p in all_points), max(p.y for p in all_points), max(p.z for p in all_points)))
+    center = (mins + maxs) * 0.5
+    ground_z = mins.z - 0.025
+
+    bone_material = material("Kimodo Cyan", (0.025, 0.48, 0.78), metallic=0.45, roughness=0.22, emission=0.15)
+    joint_material = material("Kimodo Gold", (1.0, 0.29, 0.055), metallic=0.25, roughness=0.25, emission=0.1)
+    detail_material = material("Kimodo Detail", (0.10, 0.75, 0.95), metallic=0.2, roughness=0.3)
+    trail_material = material("Motion Trail", (0.12, 0.9, 0.95), roughness=0.25, emission=2.5)
+    floor_material = material("Floor", (0.025, 0.035, 0.065), metallic=0.05, roughness=0.7)
+    sphere_mesh, cylinder_mesh = shared_meshes()
+
+    detail_tokens = ("Finger", "Thumb", "Index", "Middle", "Ring", "Pinky", "Eye", "Jaw", "Toe")
+    visuals = {}
+    for name in bone_names:
+        is_detail = any(token in name for token in detail_tokens)
+        joint = bpy.data.objects.new(f"Joint_{name}", sphere_mesh)
+        segment = bpy.data.objects.new(f"Bone_{name}", cylinder_mesh)
+        bpy.context.collection.objects.link(joint)
+        bpy.context.collection.objects.link(segment)
+        joint.data.materials.clear()
+        segment.data.materials.clear()
+        joint.data.materials.append(detail_material if is_detail else joint_material)
+        segment.data.materials.append(detail_material if is_detail else bone_material)
+        joint.rotation_mode = "QUATERNION"
+        segment.rotation_mode = "QUATERNION"
+        visuals[name] = (joint, segment, is_detail)
+
+    for frame in frames:
+        for name, (head, tail) in samples[frame].items():
+            joint, segment, is_detail = visuals[name]
+            direction = tail - head
+            length = max(direction.length, 0.001)
+            joint.location = head
+            radius = 0.013 if is_detail else 0.027
+            joint.scale = (radius, radius, radius)
+            segment.location = (head + tail) * 0.5
+            segment.rotation_quaternion = direction.to_track_quat("Z", "Y")
+            segment_radius = 0.0065 if is_detail else 0.015
+            segment.scale = (segment_radius, segment_radius, length * 0.5)
+            for obj in (joint, segment):
+                obj.keyframe_insert("location", frame=frame)
+                obj.keyframe_insert("rotation_quaternion", frame=frame)
+                obj.keyframe_insert("scale", frame=frame)
+
+    create_trail(root_points, trail_material)
+
+    floor_size = max(7.0, maxs.x - mins.x + 4.0, maxs.y - mins.y + 4.0)
+    bpy.ops.mesh.primitive_plane_add(size=floor_size, location=(center.x, center.y, ground_z))
+    floor = bpy.context.object
+    floor.name = "Ground"
+    floor.data.materials.append(floor_material)
+
+    world = scene.world or bpy.data.worlds.new("World")
+    scene.world = world
+    world.use_nodes = True
+    world.node_tree.nodes["Background"].inputs["Color"].default_value = (0.006, 0.01, 0.025, 1.0)
+    world.node_tree.nodes["Background"].inputs["Strength"].default_value = 0.18
+
+    height = maxs.z - mins.z
+    span = max(maxs.x - mins.x, maxs.y - mins.y, height)
+    target = Vector((center.x, center.y, ground_z + height * 0.52))
+    distance = max(4.2, span * 2.6)
+    camera_data = bpy.data.cameras.new("Camera")
+    camera = bpy.data.objects.new("Camera", camera_data)
+    bpy.context.collection.objects.link(camera)
+    camera.location = target + Vector((distance * 0.72, -distance, distance * 0.42))
+    camera.data.lens = 54
+    look_at(camera, target)
+    scene.camera = camera
+
+    add_area_light("Key", target + Vector((-2.8, -3.5, 4.5)), 950, 4.0, (0.55, 0.76, 1.0), target)
+    add_area_light("Fill", target + Vector((3.5, -0.5, 2.3)), 650, 3.0, (1.0, 0.32, 0.12), target)
+    add_area_light("Rim", target + Vector((0.5, 3.0, 4.0)), 1100, 3.0, (0.15, 0.55, 1.0), target)
+
+    scene.render.engine = "BLENDER_EEVEE"
+    scene.render.resolution_x = 640
+    scene.render.resolution_y = 640
+    scene.render.resolution_percentage = 100
+    scene.render.image_settings.file_format = "PNG"
+    scene.render.film_transparent = False
+    try:
+        scene.view_settings.look = "AgX - Medium High Contrast"
+    except TypeError:
+        pass
+
+    preview_frame = (scene.frame_start + scene.frame_end) // 2
+    scene.frame_set(preview_frame)
+    scene.render.filepath = os.path.join(output_dir, f"{args.name}_preview.png")
+    bpy.ops.render.render(write_still=True)
+
+    frames_dir = os.path.join(output_dir, f"{args.name}_frames")
+    os.makedirs(frames_dir, exist_ok=True)
+    scene.render.image_settings.file_format = "PNG"
+    scene.render.filepath = os.path.join(frames_dir, "frame_")
+    bpy.ops.render.render(animation=True)
+
+    blend_path = os.path.join(output_dir, f"{args.name}.blend")
+    bpy.ops.wm.save_as_mainfile(filepath=blend_path)
+
+    video_path = os.path.join(output_dir, f"{args.name}.mp4")
+    if args.ffmpeg:
+        subprocess.run(
+            [
+                os.path.abspath(args.ffmpeg),
+                "-y",
+                "-framerate",
+                str(scene.render.fps),
+                "-start_number",
+                str(scene.frame_start),
+                "-i",
+                os.path.join(frames_dir, "frame_%04d.png"),
+                "-c:v",
+                "libx264",
+                "-preset",
+                "medium",
+                "-crf",
+                "18",
+                "-pix_fmt",
+                "yuv420p",
+                "-frames:v",
+                str(scene.frame_end - scene.frame_start + 1),
+                video_path,
+            ],
+            check=True,
+        )
+
+    print(f"PREVIEW={os.path.join(output_dir, f'{args.name}_preview.png')}")
+    print(f"FRAMES={frames_dir}")
+    if args.ffmpeg:
+        print(f"VIDEO={video_path}")
+    print(f"BLEND={blend_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/extensions/Motion/ssextension.yaml
+++ b/extensions/Motion/ssextension.yaml
@@ -4,9 +4,10 @@ server:
   venv: shared
   dependencies:
     - numpy>=1.21.2
+  packages:
+    - ssui_motion
   main: extension.py
 
 web_ui:
   dist: dist/
   main: main.js
-  

--- a/extensions/Motion/ssui_motion/Kimodo.py
+++ b/extensions/Motion/ssui_motion/Kimodo.py
@@ -1,0 +1,122 @@
+import datetime
+import os
+import subprocess
+import sys
+
+from ssui.annotation import param
+from ssui.base import Prompt
+from ssui.config import SSUIConfig
+from ssui.controller import Random, Select, Slider, Switch
+
+
+KIMODO_MODELS = (
+    "Kimodo-SOMA-RP-v1.1",
+    "Kimodo-SOMA-SEED-v1.1",
+    "Kimodo-G1-RP-v1",
+    "Kimodo-G1-SEED-v1",
+)
+
+
+def _kimodo_python() -> str:
+    configured = os.environ.get("SSUI_KIMODO_PYTHON")
+    if configured:
+        return configured
+
+    candidates = (
+        os.path.join(".venv", "kimodo", "Scripts", "python.exe"),
+        os.path.join(".venv", "kimodo", "bin", "python"),
+    )
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return os.path.abspath(candidate)
+
+    raise RuntimeError(
+        "Kimodo 隔离环境不存在。请先运行 "
+        "extensions/Motion/install_kimodo.ps1。"
+    )
+
+
+def _kimodo_runner() -> str:
+    return os.path.join(os.path.dirname(__file__), "_kimodo_runner.py")
+
+
+def _run_kimodo(config: SSUIConfig, prompt: Prompt) -> str:
+    output_dir = os.path.abspath("output")
+    os.makedirs(output_dir, exist_ok=True)
+    output_stem = os.path.join(
+        output_dir,
+        "kimodo_" + datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f"),
+    )
+
+    command = [
+        _kimodo_python(),
+        _kimodo_runner(),
+        prompt.text,
+        "--model",
+        config["model"],
+        "--duration",
+        str(config["duration"]),
+        "--diffusion_steps",
+        str(config["diffusion_steps"]),
+        "--seed",
+        str(config["seed"]),
+        "--output",
+        output_stem,
+        # The Windows setup deliberately skips Kimodo's optional native
+        # motion_correction extension. Core generation does not require it.
+        "--no-postprocess",
+    ]
+    if config["export_bvh"] and "SOMA" in config["model"]:
+        command.append("--bvh")
+
+    env = os.environ.copy()
+    env.setdefault("LOCAL_CACHE", "True")
+    env.setdefault("TEXT_ENCODER_MODE", "local")
+    env["TEXT_ENCODER_DEVICE"] = config["text_encoder_device"]
+
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+    )
+    output_lines = []
+    assert process.stdout is not None
+    for line in process.stdout:
+        print(line, end="")
+        output_lines.append(line)
+    process.wait()
+
+    if process.returncode != 0:
+        tail = "".join(output_lines)[-5000:]
+        if "awaiting a review from the repo authors" in tail:
+            raise RuntimeError(
+                "Kimodo 生成失败：Hugging Face 的 Llama 3 访问申请仍在等待审批。\n"
+                + tail
+            )
+        raise RuntimeError(
+            "Kimodo 生成失败。首次运行前需要在 Kimodo 子环境执行 "
+            "`.venv\\kimodo\\Scripts\\hf.exe auth login`，并确保 Hugging Face "
+            "账号已获准访问 meta-llama/Meta-Llama-3-8B-Instruct。\n" + tail
+        )
+
+    output_path = output_stem + ".npz"
+    if not os.path.isfile(output_path):
+        raise RuntimeError("Kimodo 未生成预期文件: " + output_path)
+    return output_path
+
+
+@param("model", Select(*KIMODO_MODELS), default="Kimodo-SOMA-RP-v1.1")
+@param("duration", Slider(1, 20, 0.5), default=5.0)
+@param("diffusion_steps", Slider(1, 200, 1), default=100)
+@param("seed", Random(), default=42)
+@param("text_encoder_device", Select("cuda", "cpu"), default="cuda")
+@param("export_bvh", Switch(), default=False)
+def KimodoTextToMotion(config: SSUIConfig, prompt: Prompt) -> str:
+    """使用 NVIDIA Kimodo 从文本生成动作，返回生成的 NPZ 文件路径。"""
+    if config.is_prepare():
+        return ""
+    return _run_kimodo(config, prompt)

--- a/extensions/Motion/ssui_motion/__init__.py
+++ b/extensions/Motion/ssui_motion/__init__.py
@@ -1,0 +1,5 @@
+"""Motion-generation workflow nodes provided by the Motion extension."""
+
+from .Kimodo import KimodoTextToMotion
+
+__all__ = ["KimodoTextToMotion"]

--- a/extensions/Motion/ssui_motion/_kimodo_runner.py
+++ b/extensions/Motion/ssui_motion/_kimodo_runner.py
@@ -1,0 +1,43 @@
+"""Internal Kimodo CLI wrapper with an opt-in local text-encoder override."""
+
+import os
+
+
+def _configure_text_encoder_override() -> None:
+    base_model = os.environ.get("SSUI_KIMODO_TEXT_ENCODER_BASE")
+    if not base_model:
+        return
+
+    from kimodo.model.load_model import TEXT_ENCODER_PRESETS
+    from kimodo.model.llm2vec.llm2vec import LLM2Vec
+
+    TEXT_ENCODER_PRESETS["llm2vec"]["kwargs"]["base_model_name_or_path"] = (
+        base_model
+    )
+
+    # The supported fallback is the same Llama 3 Instruct base with the MNTP
+    # adapter merged. Its local config intentionally has no upstream repo name,
+    # so preserve the instruction framing expected by the official encoder.
+    original_prepare = LLM2Vec.prepare_for_tokenization
+
+    def prepare_for_tokenization(self, text):
+        if "Llama-3-8B-Instruct-LLM2Vec-mntp-merged" in base_model:
+            return (
+                "<|start_header_id|>user<|end_header_id|>\n\n"
+                + text.strip()
+                + "<|eot_id|>"
+            )
+        return original_prepare(self, text)
+
+    LLM2Vec.prepare_for_tokenization = prepare_for_tokenization
+
+
+def main() -> None:
+    _configure_text_encoder_override()
+    from kimodo.scripts.generate import main as kimodo_main
+
+    kimodo_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/ss_executor/__main__.py
+++ b/ss_executor/__main__.py
@@ -53,6 +53,24 @@ def convert_task_param(param):
         return [convert_task_param(item) for item in param["items"]]
     return {key: convert_task_param(value) for key, value in param.items()}
 
+
+def convert_task_return(result, task_script):
+    """Convert executor results into scheduler-safe values."""
+    if isinstance(result, tuple):
+        return [convert_task_return(item, task_script) for item in result]
+    if isinstance(result, Image):
+        current_time = datetime.datetime.now()
+        task_project_root = search_project_root(os.path.dirname(task_script))
+        output_dir = os.path.join(task_project_root, "output")
+        os.makedirs(output_dir, exist_ok=True)
+        path = os.path.join(
+            output_dir,
+            "image_" + current_time.strftime("%Y%m%d%H%M%S") + ".png",
+        )
+        result._image.save(path)
+        return {"type": "image", "path": path}
+    return result
+
 class Executor:
     def __init__(self, scheduler_url: str = None):
         self.scheduler_url = scheduler_url or os.environ.get(
@@ -153,19 +171,6 @@ class Executor:
                     print(name, param)
                     new_params[name] = convert_task_param(param)
 
-                def convert_return(result):
-                    if isinstance(result, tuple):
-                        return [convert_return(r) for r in result]
-                    
-                    if isinstance(result, Image):
-                        current_time = datetime.datetime.now()
-                        project_root = search_project_root(os.path.dirname(task.script))
-                        output_dir = os.path.join(project_root, "output")
-                        if not os.path.exists(output_dir):
-                            os.makedirs(output_dir)
-                        path = os.path.join(output_dir, "image_" + current_time.strftime("%Y%m%d%H%M%S") + ".png")
-                        result._image.save(path)
-                        return {"type": "image", "path": path}
                 # 注入配置
                 loader.config._update = task.details
                 # 执行
@@ -175,7 +180,7 @@ class Executor:
                 if not isinstance(result, tuple):
                     result = (result,)
 
-                result = convert_return(result)
+                result = convert_task_return(result, task.script)
 
             # 发送任务完成状态和结果
             task_result = TaskResult(

--- a/tests/motion_test.py
+++ b/tests/motion_test.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import unittest
+
+from ss_executor.loader import SSLoader
+
+
+class MotionExtensionTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        motion_extension = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "extensions", "Motion")
+        )
+        if motion_extension not in sys.path:
+            sys.path.insert(0, motion_extension)
+
+    def test_kimodo_node_can_be_prepared_in_sandbox(self):
+        script_path = os.path.abspath(
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "examples",
+                "advance",
+                "workflow-motion.py",
+            )
+        )
+        loader = SSLoader(use_sandbox=True)
+        loader.load(script_path)
+        loader.Execute()
+
+        config = loader.GetConfig("txt2motion_kimodo")
+        node_config = config["Kimodo Text To Motion"]
+
+        self.assertEqual(node_config["model"]["default"], "Kimodo-SOMA-RP-v1.1")
+        self.assertEqual(node_config["text_encoder_device"]["default"], "cuda")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ss_executor_test.py
+++ b/tests/ss_executor_test.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 import yaml
 from ss_executor.loader import SSLoader, SSProject, search_project_root
-from ss_executor.__main__ import convert_task_param
+from ss_executor.__main__ import convert_task_param, convert_task_return
 from ss_executor.model import Task
 from ss_executor.scheduler import TaskScheduler
 from tests.utils import should_run_model_tests
@@ -44,6 +44,10 @@ class TestSSLoader(unittest.TestCase):
         }
         result = convert_task_param(params)
         self.assertEqual([item.text for item in result], ["first", "second"])
+
+    def test_convert_primitive_task_return(self):
+        result = convert_task_return(("output/motion.npz",), "workflow.py")
+        self.assertEqual(result, ["output/motion.npz"])
         
 
 class TestSSProject(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add a Kimodo Motion extension node with an isolated child environment for Windows AMDGPU/ROCm
- keep Kimodo's official gated text encoder as the default, with an explicit opt-in local Llama 3 LLM2Vec fallback
- export generated motion as NPZ/BVH and provide a Blender 5.2-compatible preview renderer
- preserve primitive executor return values such as generated file paths and cover the behavior with a regression test

## Validation

- `node dependencies/venv.cjs python tests/run_tests.py` — 76 passed, 11 skipped
- Python compile checks for the Motion integration, Blender renderer, executor, and tests
- real Kimodo generation on AMD Radeon AI PRO R9700 through the SSUI `/api/execute` path
- generated 30-frame NPZ/BVH inspected and rendered to a 30-frame Blender preview

## Notes

- model weights, local virtual environments, Blender binaries, and generated output are ignored and are not part of this PR
- the community Llama 3 encoder path is opt-in through `SSUI_KIMODO_TEXT_ENCODER_BASE`; the official Kimodo encoder remains unchanged by default
