### PR TITLE
feat(video): add MiniMax H3 NF4 low-VRAM backend

### DIFF
--- a/examples/advance/workflow-video-local.py
+++ b/examples/advance/workflow-video-local.py
@@ -123,12 +123,10 @@ def img2vid_ltx25(image: Image, prompt: Prompt, negative_prompt: Prompt) -> Vide
 @workflow
 def txt2vid_h3(prompt: Prompt) -> Video:
     """MiniMax H3 文生视频（33B 全模态 DiT，768p + 原生音频，独立 H3 venv）。"""
-    video = H3TextToVideo(config("Generate Video"), prompt)
-    return Video("mp4", video, fps=24)
+    return H3TextToVideo(config("Generate Video"), prompt)
 
 
 @workflow
 def img2vid_h3(image: Image, prompt: Prompt, last_image: Image = None) -> Video:
     """MiniMax H3 图生视频（fl2va，可选尾帧，768p + 原生音频，独立 H3 venv）。"""
-    video = H3ImageToVideo(config("Generate Video"), image, prompt, last_image)
-    return Video("mp4", video, fps=24)
+    return H3ImageToVideo(config("Generate Video"), image, prompt, last_image)

--- a/extensions/Video/README.md
+++ b/extensions/Video/README.md
@@ -84,7 +84,9 @@ SSUI_LTX_VIDEO_VAE / SSUI_LTX_AUDIO_VAE / SSUI_LTX_SPATIAL_UPSAMPLER  单个权�
 | `H3ImageToVideo` | fl2va | 首帧 / 首尾帧视频 + 原生音频，768p |
 
 H3 是 33B 全模态 DiT，效果最接近 Seedance 2.0 的开源模型，但本地推理很吃硬件：
-80GB 单卡用 bf16 + 自动 offload；24-32GB 建议节点参数选 `int8` 量化（需安装 torchao）。
+80GB 单卡可用 bf16 + 自动 offload；24-32GB 可选 `int8`（需 torchao）。
+消费级显卡还可显式选择 `nf4`，使用 DiffSynth-Studio 的 pruned NF4 权重与磁盘卸载；
+官方标称最低 7GB 显存，但仍需约 26GiB 本地权重空间和足够的系统内存/磁盘交换空间。
 H3-Context-IR 与 2K 重生成模块官方未开源，本地只能到 768p；
 想复现官方效果需按 [Prompting Guidance](https://github.com/MiniMax-AI/MiniMax-H3) 自行预处理提示词。
 
@@ -99,11 +101,27 @@ h3-venv/Scripts/pip install -U "diffusers" "transformers" "torchao" "pyav" "Pill
 
 > diffusers 的 `ModularPipeline` / MiniMax-H3 支持是较新特性，请安装最新版。
 
+NF4 使用当前 DiffSynth-Studio，而不是扩展中兼容旧节点的 vendored 1.1.9。可在同一
+H3 venv 中安装 GitHub main，或用 `SSUI_H3_DIFFSYNTH_ROOT` 指向源码 checkout；并安装
+`bitsandbytes`（Windows AMDGPU 使用仓库 AMD requirements 中的 ROCm wheel）。下载
+`DiffSynth-Studio/MiniMax-H3-NF4` 的以下四个文件到 `models/minimax-h3-nf4/`：
+
+```text
+minimax-h3-fl2va-pruned-nf4.safetensors
+minimax-h3-text-encoder-nf4.safetensors
+video_vae_nf4.safetensors
+audio_vae_nf4.safetensors
+```
+
 环境变量：
 
 ```text
 SSUI_H3_PYTHON   H3 venv 的 python（默认探测 h3-venv 与系统 python）
 SSUI_H3_MODEL_ID 模型仓库 id（默认 MiniMaxAI/MiniMax-H3）
+SSUI_H3_NF4_MODEL_ROOT NF4 四个权重文件的目录（默认 models/minimax-h3-nf4）
+SSUI_H3_DIFFSYNTH_ROOT 当前 DiffSynth-Studio 源码目录（已安装到 venv 时可省略）
+SSUI_H3_PROCESSOR_MODEL_ID processor 仓库（默认 MiniMax/MiniMax-H3）
+SSUI_H3_VRAM_RESERVE_GIB 为激活和桌面预留的显存 GiB（默认 2）
 ```
 
 ## 工作流示例

--- a/extensions/Video/ssui_video/MiniMaxH3.py
+++ b/extensions/Video/ssui_video/MiniMaxH3.py
@@ -3,11 +3,10 @@ import shutil
 import subprocess
 import sys
 import tempfile
-
-from PIL import Image as PILImage
+import uuid
 
 from ssui.annotation import param
-from ssui.base import Prompt, Image
+from ssui.base import Prompt, Image, Video
 from ssui.config import SSUIConfig
 from ssui.controller import Random, Slider, Select
 
@@ -20,9 +19,18 @@ from ssui.controller import Random, Slider, Select
 # 建议环境变量：
 #   SSUI_H3_PYTHON   H3 venv 的 python 可执行文件（默认探测 h3-venv 与系统 python）
 #   SSUI_H3_MODEL_ID 模型仓库 id（默认 MiniMaxAI/MiniMax-H3）
+#   SSUI_H3_NF4_MODEL_ROOT  DiffSynth-Studio NF4 权重目录
+#   SSUI_H3_DIFFSYNTH_ROOT  当前 DiffSynth-Studio 源码 checkout（可选）
 H3_MODEL_ID = os.environ.get("SSUI_H3_MODEL_ID", "MiniMaxAI/MiniMax-H3")
 H3_PYTHON = os.environ.get("SSUI_H3_PYTHON", "")
 H3_RUNNER = os.path.join(os.path.dirname(__file__), "h3_runner.py")
+H3_NF4_RUNNER = os.path.join(os.path.dirname(__file__), "h3_nf4_runner.py")
+H3_NF4_MODEL_ROOT = os.environ.get(
+    "SSUI_H3_NF4_MODEL_ROOT", os.path.join("models", "minimax-h3-nf4")
+)
+H3_DIFFSYNTH_ROOT = os.environ.get("SSUI_H3_DIFFSYNTH_ROOT", "")
+H3_PROCESSOR_MODEL_ID = os.environ.get("SSUI_H3_PROCESSOR_MODEL_ID", "MiniMax/MiniMax-H3")
+H3_VRAM_RESERVE_GIB = os.environ.get("SSUI_H3_VRAM_RESERVE_GIB", "2")
 
 
 def _h3_python() -> str:
@@ -38,39 +46,45 @@ def _h3_python() -> str:
     return sys.executable
 
 
-def _read_video_frames(path: str) -> list[Image]:
-    import imageio
-
-    frames = []
-    with imageio.get_reader(path) as reader:
-        for frame in reader:
-            frames.append(Image(PILImage.fromarray(frame)))
-    return frames
-
-
 def _run_h3(
     config: SSUIConfig,
     task: str,
     prompt: Prompt,
     image: Image = None,
     last_image: Image = None,
-) -> list[Image]:
+) -> Video:
     tmpdir = tempfile.mkdtemp(prefix="ssui_h3_")
-    output = os.path.join(tmpdir, "output.mp4")
+    output_dir = os.path.abspath("output")
+    os.makedirs(output_dir, exist_ok=True)
+    output = os.path.join(output_dir, f"h3_{uuid.uuid4().hex}.mp4")
     try:
+        quantization = config["quantization"]
+        runner = H3_NF4_RUNNER if quantization == "nf4" else H3_RUNNER
         cmd = [
             _h3_python(),
-            H3_RUNNER,
+            runner,
             "--task", task,
-            "--model-id", H3_MODEL_ID,
             "--prompt", prompt.text,
             "--num-frames", str(config["num_frames"]),
+            "--num-inference-steps", str(config["num_inference_steps"]),
             "--height", str(config["height"]),
             "--width", str(config["width"]),
             "--seed", str(config["seed"]),
-            "--quantization", config["quantization"],
             "--output", output,
         ]
+        if quantization == "nf4":
+            cmd += [
+                "--model-root", H3_NF4_MODEL_ROOT,
+                "--processor-model-id", H3_PROCESSOR_MODEL_ID,
+                "--vram-reserve-gib", H3_VRAM_RESERVE_GIB,
+            ]
+            if H3_DIFFSYNTH_ROOT:
+                cmd += ["--diffsynth-root", H3_DIFFSYNTH_ROOT]
+        else:
+            cmd += [
+                "--model-id", H3_MODEL_ID,
+                "--quantization", quantization,
+            ]
         if image is not None:
             first_path = os.path.join(tmpdir, "first.png")
             image._image.save(first_path)
@@ -96,41 +110,42 @@ def _run_h3(
         if proc.returncode != 0:
             tail = "".join(log)[-3000:]
             raise RuntimeError(
-                "MiniMax H3 生成失败。请确认 h3-venv 已按说明安装（新版 diffusers / "
-                "torch>=2.7 / torchao），且已在 HF 同意 MiniMaxAI/MiniMax-H3 许可并登录。\n"
+                "MiniMax H3 生成失败。请确认 h3-venv 与所选后端依赖、权重均已安装。\n"
                 + tail
             )
         if not os.path.exists(output):
             raise RuntimeError("MiniMax H3 未生成输出文件: " + output)
-        return _read_video_frames(output)
+        return Video(format="mp4", path=output, fps=24, metadata={"audio": True})
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 @param("seed", Random(), default=42)
 @param("num_frames", Slider(5, 365, 1), default=124)
+@param("num_inference_steps", Slider(1, 60, 1), default=50)
 @param("height", Slider(32, 1536, 32), default=768)
 @param("width", Slider(32, 1536, 32), default=1344)
-@param("quantization", Select("none", "int8"), default="none")
-def H3TextToVideo(config: SSUIConfig, prompt: Prompt) -> list[Image]:
+@param("quantization", Select("none", "int8", "nf4"), default="none")
+def H3TextToVideo(config: SSUIConfig, prompt: Prompt) -> Video:
     """MiniMax H3 文生视频（t2va，768p + 原生音频；独立 H3 venv 运行）。"""
     if config.is_prepare():
-        return [Image()]
+        return Video()
     return _run_h3(config, "t2va", prompt)
 
 
 @param("seed", Random(), default=42)
 @param("num_frames", Slider(5, 365, 1), default=124)
+@param("num_inference_steps", Slider(1, 60, 1), default=50)
 @param("height", Slider(32, 1536, 32), default=768)
 @param("width", Slider(32, 1536, 32), default=1344)
-@param("quantization", Select("none", "int8"), default="none")
+@param("quantization", Select("none", "int8", "nf4"), default="none")
 def H3ImageToVideo(
     config: SSUIConfig,
     image: Image,
     prompt: Prompt,
     last_image: Image = None,
-) -> list[Image]:
+) -> Video:
     """MiniMax H3 图生视频（fl2va，可选尾帧；768p + 原生音频；独立 H3 venv 运行）。"""
     if config.is_prepare():
-        return [Image()]
+        return Video()
     return _run_h3(config, "fl2va", prompt, image=image, last_image=last_image)

--- a/extensions/Video/ssui_video/h3_nf4_runner.py
+++ b/extensions/Video/ssui_video/h3_nf4_runner.py
@@ -1,0 +1,163 @@
+"""MiniMax H3 pruned NF4 runner based on DiffSynth-Studio.
+
+This runner lives in the isolated H3 environment. Install a current
+DiffSynth-Studio checkout (or pass ``--diffsynth-root``) and bitsandbytes.
+It writes the joint video/audio result directly so SSUI does not discard the
+model's native audio track.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+NF4_FILES = (
+    "minimax-h3-fl2va-pruned-nf4.safetensors",
+    "minimax-h3-text-encoder-nf4.safetensors",
+    "video_vae_nf4.safetensors",
+    "audio_vae_nf4.safetensors",
+)
+
+
+def _prepend_diffsynth_root(root: str | None) -> None:
+    if not root:
+        return
+    path = Path(root).expanduser().resolve()
+    if not (path / "diffsynth").is_dir():
+        raise FileNotFoundError(
+            f"DiffSynth-Studio checkout not found at {path}; expected {path / 'diffsynth'}"
+        )
+    sys.path.insert(0, str(path))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="MiniMax H3 pruned NF4 inference")
+    parser.add_argument("--task", choices=["t2va", "fl2va"], default="t2va")
+    parser.add_argument("--prompt", required=True)
+    parser.add_argument("--image", default=None)
+    parser.add_argument("--last-image", default=None)
+    parser.add_argument("--num-frames", type=int, default=124)
+    parser.add_argument("--num-inference-steps", type=int, default=50)
+    parser.add_argument("--height", type=int, default=768)
+    parser.add_argument("--width", type=int, default=1344)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--model-root", required=True)
+    parser.add_argument("--diffsynth-root", default=None)
+    parser.add_argument("--processor-model-id", default="MiniMax/MiniMax-H3")
+    parser.add_argument("--vram-reserve-gib", type=float, default=2.0)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    try:
+        _prepend_diffsynth_root(args.diffsynth_root)
+
+        import torch
+
+        # The Windows ROCm build has a reduced distributed module. DiffSynth
+        # only needs these helpers here to decide whether this process may log.
+        if not hasattr(torch.distributed, "is_initialized"):
+            torch.distributed.is_initialized = lambda: False
+        if not hasattr(torch.distributed, "get_rank"):
+            torch.distributed.get_rank = lambda: 0
+
+        from diffsynth.pipelines.minimax_h3_audio_video import (
+            MiniMaxH3Pipeline,
+            ModelConfig,
+        )
+        from diffsynth.utils.data.audio_video import write_video_audio
+        from PIL import Image
+    except Exception as exc:  # noqa: BLE001
+        print(
+            "H3 NF4 运行环境不完整: %s\n"
+            "请在独立 H3 venv 中安装当前 DiffSynth-Studio、bitsandbytes、"
+            "transformers、PyAV 和 Pillow。" % exc,
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        if not torch.cuda.is_available():
+            raise RuntimeError("PyTorch 未检测到 CUDA/ROCm GPU")
+
+        model_root = Path(args.model_root).expanduser().resolve()
+        missing = [name for name in NF4_FILES if not (model_root / name).is_file()]
+        if missing:
+            raise FileNotFoundError(
+                f"H3 NF4 权重不完整（目录 {model_root}），缺少: {', '.join(missing)}"
+            )
+
+        total_vram_gib = torch.cuda.mem_get_info("cuda")[1] / (1024**3)
+        vram_limit = max(total_vram_gib - args.vram_reserve_gib, 1.0)
+        print(
+            f"加载 H3 pruned NF4：GPU={torch.cuda.get_device_name(0)}, "
+            f"总显存={total_vram_gib:.2f} GiB, 常驻上限={vram_limit:.2f} GiB"
+        )
+        vram_config = {
+            "offload_dtype": "disk",
+            "offload_device": "disk",
+            "onload_dtype": "disk",
+            "onload_device": "disk",
+            "preparing_dtype": torch.bfloat16,
+            "preparing_device": "cuda",
+            "computation_dtype": torch.bfloat16,
+            "computation_device": "cuda",
+        }
+        pipe = MiniMaxH3Pipeline.from_pretrained(
+            torch_dtype=torch.bfloat16,
+            device="cuda",
+            model_configs=[
+                ModelConfig(path=str(model_root / name), **vram_config)
+                for name in NF4_FILES
+            ],
+            processor_config=ModelConfig(
+                model_id=args.processor_model_id,
+                origin_file_pattern="FL2VA/processor/",
+            ),
+            vram_limit=vram_limit,
+        )
+
+        kwargs = {
+            "prompt": args.prompt,
+            "height": args.height,
+            "width": args.width,
+            "num_frames": args.num_frames,
+            "num_inference_steps": args.num_inference_steps,
+            "seed": args.seed,
+        }
+        if args.task == "fl2va":
+            if not args.image:
+                raise ValueError("fl2va 需要 --image 首帧")
+            keyframes = [Image.open(args.image).convert("RGB")]
+            keyframe_indices = [0]
+            if args.last_image:
+                keyframes.append(Image.open(args.last_image).convert("RGB"))
+                keyframe_indices.append(-1)
+            kwargs.update(
+                keyframes=keyframes,
+                keyframe_indices=keyframe_indices,
+            )
+
+        print("开始生成 H3 视频与音频...")
+        torch.cuda.reset_peak_memory_stats()
+        video, audio = pipe(**kwargs)
+        output = Path(args.output).expanduser().resolve()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        write_video_audio(
+            video=video,
+            audio=audio,
+            output_path=str(output),
+            fps=24,
+            audio_sample_rate=32000,
+        )
+        print(f"推理峰值显存: {torch.cuda.max_memory_allocated() / (1024**3):.2f} GiB")
+        print(f"输出已写入: {output}")
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print("MiniMax H3 NF4 推理失败: %s" % exc, file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/extensions/Video/ssui_video/h3_runner.py
+++ b/extensions/Video/ssui_video/h3_runner.py
@@ -85,6 +85,7 @@ def main() -> int:
     parser.add_argument("--image", default=None, help="首帧图片路径（fl2va）")
     parser.add_argument("--last-image", default=None, help="尾帧图片路径（fl2va）")
     parser.add_argument("--num-frames", type=int, default=124, help="帧数（自动取整到 17n+5，5-15 秒@24fps）")
+    parser.add_argument("--num-inference-steps", type=int, default=50)
     parser.add_argument("--height", type=int, default=None, help="短边建议 768，需为 32 的倍数")
     parser.add_argument("--width", type=int, default=None)
     parser.add_argument("--seed", type=int, default=42)
@@ -128,6 +129,7 @@ def main() -> int:
         call_kwargs = dict(
             prompt=args.prompt,
             num_frames=args.num_frames,
+            num_inference_steps=args.num_inference_steps,
             generator=torch.Generator().manual_seed(args.seed),
             output=["videos", "audio", "sampling_rate"],
         )

--- a/tests/minimax_h3_node_test.py
+++ b/tests/minimax_h3_node_test.py
@@ -1,0 +1,101 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from PIL import Image as PILImage
+
+from ssui import Image, Prompt, Video
+from ssui_video import MiniMaxH3
+
+
+class _Config(dict):
+    def is_prepare(self):
+        return False
+
+
+class _CompletedProcess:
+    returncode = 0
+    stdout = []
+
+    def wait(self):
+        return 0
+
+
+class TestMiniMaxH3Node(unittest.TestCase):
+    def _config(self, quantization="nf4"):
+        return _Config(
+            quantization=quantization,
+            num_frames=124,
+            num_inference_steps=1,
+            height=256,
+            width=448,
+            seed=7,
+        )
+
+    def test_nf4_uses_dedicated_runner_and_keeps_audio_container(self):
+        with tempfile.TemporaryDirectory() as root, patch.object(
+            MiniMaxH3, "H3_PYTHON", "h3-python"
+        ), patch.object(
+            MiniMaxH3, "H3_NF4_MODEL_ROOT", "nf4-models"
+        ), patch.object(
+            MiniMaxH3, "H3_DIFFSYNTH_ROOT", "diffsynth-main"
+        ), patch.object(
+            MiniMaxH3.subprocess, "Popen"
+        ) as popen:
+            original_cwd = os.getcwd()
+            os.chdir(root)
+            try:
+                def create_output(command, **_kwargs):
+                    output = Path(command[command.index("--output") + 1])
+                    output.parent.mkdir(parents=True, exist_ok=True)
+                    output.write_bytes(b"mp4")
+                    return _CompletedProcess()
+
+                popen.side_effect = create_output
+                result = MiniMaxH3._run_h3(
+                    self._config(), "t2va", Prompt("a speaking robot")
+                )
+            finally:
+                os.chdir(original_cwd)
+
+        command = popen.call_args.args[0]
+        self.assertIsInstance(result, Video)
+        self.assertTrue(result.path.endswith(".mp4"))
+        self.assertEqual(result.metadata, {"audio": True})
+        self.assertEqual(command[1], MiniMaxH3.H3_NF4_RUNNER)
+        self.assertIn("--model-root", command)
+        self.assertIn("nf4-models", command)
+        self.assertIn("--diffsynth-root", command)
+        self.assertNotIn("--quantization", command)
+
+    def test_fl2va_passes_first_and_last_keyframes(self):
+        first = Image(PILImage.new("RGB", (32, 32), "red"))
+        last = Image(PILImage.new("RGB", (32, 32), "blue"))
+        with tempfile.TemporaryDirectory() as root, patch.object(
+            MiniMaxH3, "H3_PYTHON", "h3-python"
+        ), patch.object(MiniMaxH3.subprocess, "Popen") as popen:
+            original_cwd = os.getcwd()
+            os.chdir(root)
+            try:
+                def create_output(command, **_kwargs):
+                    output = Path(command[command.index("--output") + 1])
+                    output.parent.mkdir(parents=True, exist_ok=True)
+                    output.write_bytes(b"mp4")
+                    return _CompletedProcess()
+
+                popen.side_effect = create_output
+                MiniMaxH3._run_h3(
+                    self._config(), "fl2va", Prompt("transition"), first, last
+                )
+            finally:
+                os.chdir(original_cwd)
+
+        command = popen.call_args.args[0]
+        self.assertIn("--image", command)
+        self.assertIn("--last-image", command)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an opt-in DiffSynth-Studio pruned NF4 backend for MiniMax H3 while preserving the existing bf16 and int8 paths
- keep H3 native audio by returning the generated MP4 as an SSUI Video instead of decoding it into silent image frames
- expose inference-step control, FL2VA first/last keyframes, low-VRAM disk offload, environment configuration, and focused node tests

## Validation

- repository Python test entrypoint: 98 passed, 11 skipped
- Python compile checks passed for both H3 runners, the node, and its tests
- Windows AMDGPU / Radeon AI PRO R9700 real inference: 50 steps, 448x256, 124 frames, 5.175 seconds
- DiffSynth resident VRAM limit: 6.00 GiB; measured PyTorch peak allocation: 5.71 GiB
- output verified as 124-frame H.264 video plus non-silent 32 kHz stereo AAC audio

The low-VRAM run used a 32 GiB GPU with DiffSynth constrained to a 6 GiB model-residency budget. It is positive evidence for the advertised 7-8 GiB path, but not a physical 8 GiB GPU test.
