### PR TITLE
feat(config): 完善系统通用配置

### DIFF
--- a/frontend/functional_ui/src/config/ConfigContext.tsx
+++ b/frontend/functional_ui/src/config/ConfigContext.tsx
@@ -14,16 +14,20 @@ export interface ConfigContextValue {
     config: UiConfig;
     loaded: boolean;
     saveStatus: ConfigSaveStatus;
+    saveError: string | null;
     updateConfig: (patch: Partial<UiConfig>) => void;
     saveConfig: () => Promise<void>;
+    resetConfig: () => void;
 }
 
 const ConfigContext = createContext<ConfigContextValue>({
     config: DEFAULT_UI_CONFIG,
     loaded: false,
     saveStatus: 'saved',
+    saveError: null,
     updateConfig: () => {},
     saveConfig: async () => {},
+    resetConfig: () => {},
 });
 
 export const ConfigProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -35,44 +39,66 @@ export const ConfigProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     const [config, setConfig] = useState<UiConfig>(DEFAULT_UI_CONFIG);
     const [loaded, setLoaded] = useState(false);
     const [saveStatus, setSaveStatus] = useState<ConfigSaveStatus>('saved');
+    const [saveError, setSaveError] = useState<string | null>(null);
 
     const pendingPatchRef = useRef<Partial<UiConfig>>({});
     const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const savingPromiseRef = useRef<Promise<void> | null>(null);
 
     const saveConfig = useCallback(async () => {
-        const patch = pendingPatchRef.current;
-        if (Object.keys(patch).length === 0) {
-            return;
-        }
-        pendingPatchRef.current = {};
         if (saveTimerRef.current) {
             clearTimeout(saveTimerRef.current);
             saveTimerRef.current = null;
         }
-
-        setSaveStatus('saving');
-        try {
-            const saved = await serviceRef.current!.save(patch);
-            setConfig(saved);
-            setSaveStatus('saved');
-        } catch (error) {
-            console.error('保存配置失败:', error);
-            // 保存失败时把补丁放回待保存队列，供下次 update/save 重试
-            pendingPatchRef.current = { ...patch, ...pendingPatchRef.current };
-            setSaveStatus('unsaved');
+        if (savingPromiseRef.current) {
+            return savingPromiseRef.current;
         }
+
+        const run = async () => {
+            while (Object.keys(pendingPatchRef.current).length > 0) {
+                const patch = pendingPatchRef.current;
+                pendingPatchRef.current = {};
+                setSaveStatus('saving');
+                setSaveError(null);
+                try {
+                    const saved = await serviceRef.current!.save(patch);
+                    // 保存期间产生的新修改必须继续保留在乐观 UI 中。
+                    setConfig({ ...saved, ...pendingPatchRef.current });
+                } catch (error) {
+                    console.error('保存配置失败:', error);
+                    pendingPatchRef.current = { ...patch, ...pendingPatchRef.current };
+                    setSaveError(error instanceof Error ? error.message : '保存配置失败');
+                    setSaveStatus('error');
+                    return;
+                }
+            }
+            setSaveStatus('saved');
+        };
+
+        savingPromiseRef.current = run().finally(() => {
+            savingPromiseRef.current = null;
+        });
+        return savingPromiseRef.current;
     }, []);
 
     const updateConfig = useCallback((patch: Partial<UiConfig>) => {
         pendingPatchRef.current = { ...pendingPatchRef.current, ...patch };
         setConfig(prev => ({ ...prev, ...patch }));
+        serviceRef.current!.cache(patch);
+        setSaveError(null);
         setSaveStatus('unsaved');
 
         if (saveTimerRef.current) {
             clearTimeout(saveTimerRef.current);
         }
-        saveTimerRef.current = setTimeout(saveConfig, 500);
+        saveTimerRef.current = setTimeout(() => {
+            void saveConfig();
+        }, 500);
     }, [saveConfig]);
+
+    const resetConfig = useCallback(() => {
+        updateConfig(DEFAULT_UI_CONFIG);
+    }, [updateConfig]);
 
     // 启动时先按默认主题渲染，再加载持久化配置
     useEffect(() => {
@@ -82,7 +108,8 @@ export const ConfigProvider: React.FC<{ children: React.ReactNode }> = ({ childr
             if (cancelled) {
                 return;
             }
-            setConfig(cfg);
+            // 加载期间产生的乐观修改优先于服务端快照。
+            setConfig({ ...cfg, ...pendingPatchRef.current });
             setLoaded(true);
         });
         return () => {
@@ -116,7 +143,15 @@ export const ConfigProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     }, []);
 
     return (
-        <ConfigContext.Provider value={{ config, loaded, saveStatus, updateConfig, saveConfig }}>
+        <ConfigContext.Provider value={{
+            config,
+            loaded,
+            saveStatus,
+            saveError,
+            updateConfig,
+            saveConfig,
+            resetConfig,
+        }}>
             {children}
         </ConfigContext.Provider>
     );

--- a/frontend/functional_ui/src/config/configService.ts
+++ b/frontend/functional_ui/src/config/configService.ts
@@ -53,9 +53,21 @@ export class ConfigService {
         }
     }
 
-    async save(patch: Partial<UiConfig>): Promise<UiConfig> {
-        await this.message.post('config/', { ui: patch });
+    /**
+     * 先同步写入本地缓存，确保用户在自动保存计时结束前关闭页面时也不会丢失修改。
+     */
+    cache(patch: Partial<UiConfig>): UiConfig {
         const config = normalizeUiConfig({ ...readCache(), ...patch });
+        writeCache(config);
+        return config;
+    }
+
+    async save(patch: Partial<UiConfig>): Promise<UiConfig> {
+        const response = await this.message.post('config/', { ui: patch });
+        const serverConfig = response?.ui as Partial<UiConfig> | undefined;
+        const config = normalizeUiConfig(
+            serverConfig ?? { ...readCache(), ...patch }
+        );
         writeCache(config);
         return config;
     }

--- a/frontend/functional_ui/src/config/types.ts
+++ b/frontend/functional_ui/src/config/types.ts
@@ -20,4 +20,4 @@ export const DEFAULT_UI_CONFIG: UiConfig = {
     civitai_token: '',
 };
 
-export type ConfigSaveStatus = 'saved' | 'saving' | 'unsaved';
+export type ConfigSaveStatus = 'saved' | 'saving' | 'unsaved' | 'error';

--- a/frontend/functional_ui/src/ui/settings/ProjectSettings.css
+++ b/frontend/functional_ui/src/ui/settings/ProjectSettings.css
@@ -1,265 +1,381 @@
 .project-settings {
-  max-width: 1200px;
+  width: min(980px, calc(100% - 48px));
   margin: 0 auto;
-  padding: 20px;
-  font-family: 'Arial', sans-serif;
+  padding: 48px 0 72px;
+  color: var(--ssui-fg);
+}
+
+.settings-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 32px;
+  padding-bottom: 26px;
+  border-bottom: 1px solid var(--ssui-card-border);
+}
+
+.settings-eyebrow {
+  margin-bottom: 8px;
+  color: var(--ssui-primary);
+  font: 700 11px/1.2 ui-monospace, SFMono-Regular, Consolas, monospace;
+  letter-spacing: 0.16em;
 }
 
 .settings-title {
-  font-size: 24px;
-  margin-bottom: 20px;
+  margin: 0;
   color: var(--ssui-fg);
-  border-bottom: 1px solid var(--ssui-card-border);
-  padding-bottom: 10px;
+  font-size: clamp(30px, 5vw, 44px);
+  font-weight: 650;
+  line-height: 1.08;
+  letter-spacing: -0.04em;
+}
+
+.settings-subtitle {
+  max-width: 560px;
+  margin: 12px 0 0;
+  color: var(--ssui-fg-muted);
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+.settings-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 0 0 auto;
+}
+
+.secondary-button,
+.save-error button {
+  min-height: 34px;
+  padding: 7px 12px;
+  border: 1px solid var(--ssui-border);
+  border-radius: 6px;
+  color: var(--ssui-fg);
+  background: var(--ssui-input-bg);
+  font: inherit;
+  font-size: 13px;
+}
+
+.secondary-button:hover:not(:disabled),
+.save-error button:hover {
+  border-color: var(--ssui-primary);
+}
+
+.secondary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.save-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  padding: 0 11px;
+  border: 1px solid var(--ssui-card-border);
+  border-radius: 999px;
+  color: var(--ssui-fg-muted);
+  background: var(--ssui-card-bg);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #3ba55d;
+  box-shadow: 0 0 0 3px rgba(59, 165, 93, 0.12);
+}
+
+.save-status.saving .status-dot,
+.save-status.unsaved .status-dot {
+  background: #d99b2b;
+  box-shadow: 0 0 0 3px rgba(217, 155, 43, 0.14);
+}
+
+.save-status.saving .status-dot {
+  animation: status-pulse 1.1s ease-in-out infinite;
+}
+
+.save-status.error .status-dot {
+  background: var(--ssui-danger);
+  box-shadow: 0 0 0 3px rgba(255, 77, 79, 0.14);
 }
 
 .settings-content {
-  display: flex;
-  flex-direction: column;
-  gap: 30px;
+  display: grid;
+  gap: 18px;
+  margin-top: 28px;
 }
 
 .config-group {
-  background-color: var(--ssui-card-bg);
-  border-radius: 8px;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
-  padding: 20px;
+  overflow: hidden;
+  border: 1px solid var(--ssui-card-border);
+  border-radius: 10px;
+  background: var(--ssui-card-bg);
+  box-shadow: 0 8px 30px rgba(10, 25, 50, 0.035);
 }
 
 .config-group-title {
-  font-size: 18px;
-  margin-bottom: 15px;
-  color: var(--ssui-fg);
+  margin: 0;
+  padding: 16px 20px;
   border-bottom: 1px solid var(--ssui-card-border);
-  padding-bottom: 8px;
+  color: var(--ssui-fg-muted);
+  background: color-mix(in srgb, var(--ssui-card-bg) 86%, var(--ssui-primary) 14%);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
 }
 
 .config-items {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-}
-
-.config-input {
-  width: 100%;
-  padding: 8px 12px;
-  border: 1px solid var(--ssui-border);
-  border-radius: 4px;
-  background-color: var(--ssui-input-bg);
-  color: var(--ssui-fg);
 }
 
 .config-item {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 15px;
-  border-radius: 6px;
-  background-color: var(--ssui-item-bg);
-  transition: background-color 0.2s;
-}
-
-.config-item:hover {
-  background-color: var(--ssui-hover-bg);
-}
-
-.config-header {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) minmax(260px, 0.82fr);
   align-items: center;
+  gap: 36px;
+  padding: 20px;
+}
+
+.config-item + .config-item {
+  border-top: 1px solid var(--ssui-card-border);
 }
 
 .config-label {
-  font-weight: 600;
+  display: block;
   color: var(--ssui-fg);
+  font-size: 14px;
+  font-weight: 600;
 }
 
-.config-tooltip {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background-color: var(--ssui-hover-bg);
+.config-description {
+  margin: 5px 0 0;
   color: var(--ssui-fg-muted);
-  display: flex;
-  align-items: center;
-  justify-content: center;
   font-size: 12px;
-  cursor: help;
-  transition: background-color 0.2s;
-}
-
-.config-tooltip:hover {
-  background-color: var(--ssui-item-bg);
+  line-height: 1.55;
 }
 
 .config-control {
-  margin-top: 5px;
+  min-width: 0;
 }
 
-/* 布尔类型样式 */
-.config-control input[type="checkbox"] {
-  width: 18px;
-  height: 18px;
+.config-input-row {
+  display: flex;
+  gap: 8px;
+}
+
+.config-input,
+.config-control select,
+.list-add input,
+.dict-control input {
+  width: 100%;
+  min-height: 38px;
+  box-sizing: border-box;
+  padding: 8px 11px;
+  border: 1px solid var(--ssui-border);
+  border-radius: 6px;
+  color: var(--ssui-fg);
+  background: var(--ssui-input-bg);
+  font: inherit;
+  font-size: 13px;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.config-input:focus,
+.config-control select:focus,
+.list-add input:focus,
+.dict-control input:focus,
+.secondary-button:focus-visible,
+.save-error button:focus-visible {
+  border-color: var(--ssui-primary);
+  outline: none !important;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ssui-primary) 18%, transparent);
+}
+
+.reveal-button {
+  min-width: 54px;
+}
+
+.toggle-control {
+  justify-self: end;
   cursor: pointer;
 }
 
-/* 枚举类型样式 */
-.config-control select {
-  width: 100%;
-  padding: 8px 12px;
-  border: 1px solid var(--ssui-border);
-  border-radius: 4px;
-  background-color: var(--ssui-input-bg);
-  color: var(--ssui-fg);
-  font-size: 14px;
+.toggle-control input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
 }
 
-/* 列表类型样式 */
-.list-control {
+.toggle-track {
+  display: block;
+  width: 42px;
+  height: 24px;
+  padding: 3px;
+  box-sizing: border-box;
+  border-radius: 999px;
+  background: var(--ssui-border);
+  transition: background 150ms ease, box-shadow 150ms ease;
+}
+
+.toggle-track span {
+  display: block;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.22);
+  transition: transform 150ms ease;
+}
+
+.toggle-control input:checked + .toggle-track {
+  background: var(--ssui-primary);
+}
+
+.toggle-control input:checked + .toggle-track span {
+  transform: translateX(18px);
+}
+
+.toggle-control input:focus-visible + .toggle-track {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ssui-primary) 20%, transparent);
+}
+
+.save-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-top: 20px;
+  padding: 14px 16px;
+  border: 1px solid color-mix(in srgb, var(--ssui-danger) 48%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--ssui-danger) 8%, var(--ssui-card-bg));
+}
+
+.save-error div {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 3px;
 }
 
+.save-error strong {
+  font-size: 13px;
+}
+
+.save-error span,
+.settings-loading {
+  color: var(--ssui-fg-muted);
+  font-size: 12px;
+}
+
+.settings-loading {
+  margin-top: 28px;
+  padding: 52px;
+  border: 1px dashed var(--ssui-border);
+  border-radius: 10px;
+  text-align: center;
+}
+
+.list-control,
+.dict-control,
 .list-items {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-.list-item {
+.list-item,
+.list-add,
+.dict-add {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 8px 12px;
-  background-color: var(--ssui-input-bg);
-  border: 1px solid var(--ssui-card-border);
-  border-radius: 4px;
-}
-
-.list-item button {
-  background-color: var(--ssui-danger);
-  color: white;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 8px;
-  cursor: pointer;
-  font-size: 12px;
-}
-
-.list-add {
-  display: flex;
   gap: 8px;
 }
 
-.list-add input {
-  flex: 1;
-  padding: 8px 12px;
-  border: 1px solid var(--ssui-border);
-  border-radius: 4px;
-  background-color: var(--ssui-input-bg);
-  color: var(--ssui-fg);
+.list-item {
+  justify-content: space-between;
+  padding: 8px 10px;
+  border: 1px solid var(--ssui-card-border);
+  border-radius: 6px;
 }
 
-.list-add button {
-  background-color: var(--ssui-primary);
-  color: white;
-  border: none;
-  border-radius: 4px;
-  padding: 8px 12px;
-  cursor: pointer;
+.list-item button,
+.dict-table button,
+.list-add button,
+.dict-add button {
+  padding: 6px 9px;
+  border: 0;
+  border-radius: 5px;
+  color: #fff;
+  background: var(--ssui-primary);
 }
 
-/* 字典类型样式 */
-.dict-control {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+.list-item button,
+.dict-table button {
+  background: var(--ssui-danger);
 }
 
 .dict-table {
   width: 100%;
   border-collapse: collapse;
-  margin-bottom: 10px;
 }
 
-.dict-table th, .dict-table td {
-  padding: 8px 12px;
-  text-align: left;
-  border-bottom: 1px solid var(--ssui-card-border);
-}
-
-.dict-table th {
-  background-color: var(--ssui-table-header-bg);
-  font-weight: 600;
-}
-
-.dict-table input {
-  width: 100%;
-  padding: 6px 8px;
-  border: 1px solid var(--ssui-border);
-  border-radius: 4px;
-  background-color: var(--ssui-input-bg);
-  color: var(--ssui-fg);
-}
-
-.dict-table button {
-  background-color: var(--ssui-danger);
-  color: white;
-  border: none;
-  border-radius: 4px;
-  padding: 4px 8px;
-  cursor: pointer;
+.dict-table th,
+.dict-table td {
+  padding: 5px;
+  color: var(--ssui-fg-muted);
   font-size: 12px;
+  text-align: left;
 }
 
-.dict-add {
-  display: flex;
-  gap: 8px;
+@keyframes status-pulse {
+  50% { opacity: 0.4; }
 }
 
-.dict-add input {
-  flex: 1;
-  padding: 8px 12px;
-  border: 1px solid var(--ssui-border);
-  border-radius: 4px;
-  background-color: var(--ssui-input-bg);
-  color: var(--ssui-fg);
+@media (max-width: 720px) {
+  .project-settings {
+    width: min(100% - 28px, 980px);
+    padding-top: 28px;
+  }
+
+  .settings-header,
+  .settings-actions,
+  .save-error {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .settings-actions {
+    gap: 8px;
+  }
+
+  .save-status {
+    justify-content: center;
+  }
+
+  .config-item {
+    grid-template-columns: 1fr;
+    gap: 14px;
+  }
+
+  .toggle-control {
+    justify-self: start;
+  }
 }
 
-.dict-add button {
-  background-color: var(--ssui-primary);
-  color: white;
-  border: none;
-  border-radius: 4px;
-  padding: 8px 12px;
-  cursor: pointer;
-}
+@media (prefers-reduced-motion: reduce) {
+  .save-status.saving .status-dot {
+    animation: none;
+  }
 
-.settings-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 20px;
+  .toggle-track,
+  .toggle-track span {
+    transition: none;
+  }
 }
-
-.save-status {
-  padding: 4px 8px;
-  border-radius: 4px;
-  font-size: 14px;
-}
-
-.save-status.saved {
-  color: #52c41a;
-  background-color: rgba(82, 196, 26, 0.15);
-}
-
-.save-status.saving {
-  color: #1890ff;
-  background-color: rgba(24, 144, 255, 0.15);
-}
-
-.save-status.unsaved {
-  color: #faad14;
-  background-color: rgba(250, 173, 20, 0.15);
-} 

--- a/frontend/functional_ui/src/ui/settings/ProjectSettings.tsx
+++ b/frontend/functional_ui/src/ui/settings/ProjectSettings.tsx
@@ -1,280 +1,211 @@
-import React, { useState } from 'react';
-import { ConfigItem, ConfigGroup } from './types';
+import React, { useId, useState } from 'react';
+import { ConfigGroup, ConfigItem } from './types';
 import './ProjectSettings.css';
-import { registerUIProvider, UIProvider } from '../UIProvider';
+import { UIProvider } from '../UIProvider';
 import { useProjectSettings } from './useProjectSettings';
 
-// 布尔类型配置项组件
-const BooleanConfig: React.FC<{ item: ConfigItem; value: boolean; onChange: (value: boolean) => void }> = ({ item, value, onChange }) => {
+interface ConfigControlProps<T> {
+  item: ConfigItem;
+  value: T;
+  onChange: (value: T) => void;
+}
+
+const ConfigCopy: React.FC<{ item: ConfigItem; inputId?: string }> = ({ item, inputId }) => (
+  <div className="config-copy">
+    <label className="config-label" htmlFor={inputId}>{item.name}</label>
+    <p className="config-description">{item.description}</p>
+  </div>
+);
+
+const BooleanConfig: React.FC<ConfigControlProps<boolean>> = ({ item, value, onChange }) => {
+  const inputId = useId();
   return (
-    <div className="config-item">
-      <div className="config-header">
-        <label className="config-label">{item.name}</label>
-        <div className="config-tooltip" title={item.description}>?</div>
-      </div>
-      <div className="config-control">
-        <input
-          type="checkbox"
-          checked={value}
-          onChange={(e) => onChange(e.target.checked)}
-        />
-      </div>
+    <div className="config-item config-item-toggle">
+      <ConfigCopy item={item} inputId={inputId} />
+      <label className="toggle-control" htmlFor={inputId}>
+        <input id={inputId} type="checkbox" checked={Boolean(value)} onChange={(event) => onChange(event.target.checked)} />
+        <span className="toggle-track" aria-hidden="true"><span /></span>
+      </label>
     </div>
   );
 };
 
-// 枚举类型配置项组件
-const EnumConfig: React.FC<{ item: ConfigItem; value: string; onChange: (value: string) => void }> = ({ item, value, onChange }) => {
+const EnumConfig: React.FC<ConfigControlProps<string>> = ({ item, value, onChange }) => {
+  const inputId = useId();
   return (
     <div className="config-item">
-      <div className="config-header">
-        <label className="config-label">{item.name}</label>
-        <div className="config-tooltip" title={item.description}>?</div>
-      </div>
+      <ConfigCopy item={item} inputId={inputId} />
       <div className="config-control">
-        <select value={value} onChange={(e) => onChange(e.target.value)}>
-          {item.options?.map((option) => (
-            <option key={option} value={option}>{option}</option>
-          ))}
+        <select id={inputId} value={value ?? ''} onChange={(event) => onChange(event.target.value)}>
+          {item.options?.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
         </select>
       </div>
     </div>
   );
 };
 
-const StringConfig: React.FC<{ item: ConfigItem; value: string; onChange: (value: string) => void }> = ({ item, value, onChange }) => {
+const StringConfig: React.FC<ConfigControlProps<string>> = ({ item, value, onChange }) => {
+  const inputId = useId();
+  const [revealed, setRevealed] = useState(false);
   return (
     <div className="config-item">
-      <div className="config-header">
-        <label className="config-label">{item.name}</label>
-        <div className="config-tooltip" title={item.description}>?</div>
-      </div>
-      <div className="config-control">
-        <input className="config-input" type="text" value={value} onChange={(e) => onChange(e.target.value)} />
+      <ConfigCopy item={item} inputId={inputId} />
+      <div className="config-control config-input-row">
+        <input
+          id={inputId}
+          className="config-input"
+          type={item.sensitive && !revealed ? 'password' : 'text'}
+          value={value ?? ''}
+          placeholder={item.placeholder}
+          autoComplete={item.sensitive ? 'off' : undefined}
+          onChange={(event) => onChange(event.target.value)}
+        />
+        {item.sensitive && (
+          <button className="secondary-button reveal-button" type="button" onClick={() => setRevealed(current => !current)}>
+            {revealed ? '隐藏' : '显示'}
+          </button>
+        )}
       </div>
     </div>
   );
 };
 
-// 列表类型配置项组件
-const ListConfig: React.FC<{ item: ConfigItem; value: string[]; onChange: (value: string[]) => void }> = ({ item, value, onChange }) => {
+const ListConfig: React.FC<ConfigControlProps<string[]>> = ({ item, value = [], onChange }) => {
   const [newItem, setNewItem] = useState('');
-  
-  const handleAdd = () => {
-    if (newItem.trim()) {
-      onChange([...value, newItem.trim()]);
+  const addItem = () => {
+    const nextItem = newItem.trim();
+    if (nextItem) {
+      onChange([...value, nextItem]);
       setNewItem('');
     }
   };
-  
-  const handleRemove = (index: number) => {
-    const newList = [...value];
-    newList.splice(index, 1);
-    onChange(newList);
-  };
-  
   return (
     <div className="config-item">
-      <div className="config-header">
-        <label className="config-label">{item.name}</label>
-        <div className="config-tooltip" title={item.description}>?</div>
-      </div>
+      <ConfigCopy item={item} />
       <div className="config-control list-control">
         <div className="list-items">
-          {value.map((listItem, index) => (
-            <div key={index} className="list-item">
-              <span>{listItem}</span>
-              <button onClick={() => handleRemove(index)}>删除</button>
+          {value.map((entry, index) => (
+            <div key={`${entry}-${index}`} className="list-item">
+              <span>{entry}</span>
+              <button type="button" onClick={() => onChange(value.filter((_, itemIndex) => itemIndex !== index))}>删除</button>
             </div>
           ))}
         </div>
         <div className="list-add">
-          <input
-            type="text"
-            value={newItem}
-            onChange={(e) => setNewItem(e.target.value)}
-            placeholder="添加新项"
-          />
-          <button onClick={handleAdd}>添加</button>
+          <input value={newItem} onChange={(event) => setNewItem(event.target.value)} onKeyDown={(event) => event.key === 'Enter' && addItem()} placeholder="添加新项" />
+          <button type="button" onClick={addItem}>添加</button>
         </div>
       </div>
     </div>
   );
 };
 
-// 字典类型配置项组件
-const DictConfig: React.FC<{ 
-  item: ConfigItem; 
-  value: { key: string; value: string }[]; 
-  onChange: (value: { key: string; value: string }[]) => void 
-}> = ({ item, value, onChange }) => {
+type DictEntry = { key: string; value: string };
+
+const DictConfig: React.FC<ConfigControlProps<DictEntry[]>> = ({ item, value = [], onChange }) => {
   const [newKey, setNewKey] = useState('');
   const [newValue, setNewValue] = useState('');
-  
-  const handleAdd = () => {
+  const addItem = () => {
     if (newKey.trim() && newValue.trim()) {
       onChange([...value, { key: newKey.trim(), value: newValue.trim() }]);
       setNewKey('');
       setNewValue('');
     }
   };
-  
-  const handleRemove = (index: number) => {
-    const newItems = [...value];
-    newItems.splice(index, 1);
-    onChange(newItems);
+  const editItem = (index: number, field: keyof DictEntry, fieldValue: string) => {
+    onChange(value.map((entry, itemIndex) => itemIndex === index ? { ...entry, [field]: fieldValue } : entry));
   };
-  
-  const handleEdit = (index: number, field: 'key' | 'value', newValue: string) => {
-    const newItems = [...value];
-    newItems[index] = { ...newItems[index], [field]: newValue };
-    onChange(newItems);
-  };
-  
   return (
     <div className="config-item">
-      <div className="config-header">
-        <label className="config-label">{item.name}</label>
-        <div className="config-tooltip" title={item.description}>?</div>
-      </div>
+      <ConfigCopy item={item} />
       <div className="config-control dict-control">
         <table className="dict-table">
-          <thead>
-            <tr>
-              <th>键</th>
-              <th>值</th>
-              <th>操作</th>
-            </tr>
-          </thead>
+          <thead><tr><th>键</th><th>值</th><th>操作</th></tr></thead>
           <tbody>
-            {value.map((dictItem, index) => (
+            {value.map((entry, index) => (
               <tr key={index}>
-                <td>
-                  <input
-                    type="text"
-                    value={dictItem.key}
-                    onChange={(e) => handleEdit(index, 'key', e.target.value)}
-                  />
-                </td>
-                <td>
-                  <input
-                    type="text"
-                    value={dictItem.value}
-                    onChange={(e) => handleEdit(index, 'value', e.target.value)}
-                  />
-                </td>
-                <td>
-                  <button onClick={() => handleRemove(index)}>删除</button>
-                </td>
+                <td><input value={entry.key} onChange={(event) => editItem(index, 'key', event.target.value)} /></td>
+                <td><input value={entry.value} onChange={(event) => editItem(index, 'value', event.target.value)} /></td>
+                <td><button type="button" onClick={() => onChange(value.filter((_, itemIndex) => itemIndex !== index))}>删除</button></td>
               </tr>
             ))}
           </tbody>
         </table>
         <div className="dict-add">
-          <input
-            type="text"
-            value={newKey}
-            onChange={(e) => setNewKey(e.target.value)}
-            placeholder="键"
-          />
-          <input
-            type="text"
-            value={newValue}
-            onChange={(e) => setNewValue(e.target.value)}
-            placeholder="值"
-          />
-          <button onClick={handleAdd}>添加</button>
+          <input value={newKey} onChange={(event) => setNewKey(event.target.value)} placeholder="键" />
+          <input value={newValue} onChange={(event) => setNewValue(event.target.value)} placeholder="值" />
+          <button type="button" onClick={addItem}>添加</button>
         </div>
       </div>
     </div>
   );
 };
 
-// 配置项组件
-const ConfigItemComponent: React.FC<{ 
-  item: ConfigItem; 
-  value: any;
-  onChange: (value: any) => void 
-}> = ({ item, value, onChange }) => {
-  switch (item.type) {
-    case 'boolean':
-      return <BooleanConfig item={item} value={value} onChange={onChange} />;
-    case 'string':
-      return <StringConfig item={item} value={value} onChange={onChange} />;
-    case 'enum':
-      return <EnumConfig item={item} value={value} onChange={onChange} />;
-    case 'list':
-      return <ListConfig item={item} value={value} onChange={onChange} />;
-    case 'dict':
-      return <DictConfig item={item} value={value} onChange={onChange} />;
-    default:
-      return <div>不支持的配置类型: {item.type}</div>;
+const ConfigItemComponent: React.FC<ConfigControlProps<any>> = (props) => {
+  switch (props.item.type) {
+    case 'boolean': return <BooleanConfig {...props} />;
+    case 'string': return <StringConfig {...props} />;
+    case 'enum': return <EnumConfig {...props} />;
+    case 'list': return <ListConfig {...props} />;
+    case 'dict': return <DictConfig {...props} />;
   }
 };
 
-// 配置组组件
-const ConfigGroupComponent: React.FC<{ 
+const ConfigGroupComponent: React.FC<{
   group: ConfigGroup;
   userInput: { [key: string]: any };
-  onConfigChange: (groupTitle: string, itemName: string, value: any) => void 
-}> = ({ group, userInput, onConfigChange }) => {
-  return (
-    <div className="config-group">
-      <h2 className="config-group-title">{group.title}</h2>
-      <div className="config-items">
-        {group.items.map((item) => (
-          <ConfigItemComponent
-            key={item.name}
-            item={item}
-            value={userInput[item.name]?.value}
-            onChange={(value) => onConfigChange(group.title, item.name, value)}
-          />
-        ))}
-      </div>
+  onConfigChange: (groupTitle: string, itemName: string, value: any) => void;
+}> = ({ group, userInput, onConfigChange }) => (
+  <section className="config-group">
+    <h2 className="config-group-title">{group.title}</h2>
+    <div className="config-items">
+      {group.items.map((item) => (
+        <ConfigItemComponent key={item.key} item={item} value={userInput[item.name]?.value} onChange={(value) => onConfigChange(group.title, item.name, value)} />
+      ))}
     </div>
-  );
-};
+  </section>
+);
 
-// 主配置页面组件
-interface ProjectSettingsProps {
-  path: string;
-}
+const ProjectSettings: React.FC<{ path: string }> = ({ path }) => {
+  const settings = useProjectSettings(path);
+  const statusText = {
+    saved: '所有更改已保存',
+    saving: '正在保存…',
+    unsaved: '等待保存',
+    error: '保存失败',
+  }[settings.saveStatus];
 
-const ProjectSettings: React.FC<ProjectSettingsProps> = ({ path }) => {
-  const { uiConfig, userInput, saveStatus, handleConfigChange } = useProjectSettings(path);
-  
   return (
     <div className="project-settings">
-      <div className="settings-header">
-        <h1 className="settings-title">项目设置: {path}</h1>
-        <div className={`save-status ${saveStatus}`}>
-          {saveStatus === 'saved' && '已保存'}
-          {saveStatus === 'saving' && '保存中...'}
-          {saveStatus === 'unsaved' && '未保存'}
+      <header className="settings-header">
+        <div>
+          <div className="settings-eyebrow">SSUI / PREFERENCES</div>
+          <h1 className="settings-title">通用配置</h1>
+          <p className="settings-subtitle">管理界面外观、工作方式和外部服务。更改会自动保存到本机。</p>
         </div>
-      </div>
-      <div className="settings-content">
-        {uiConfig.map((group) => (
-          <ConfigGroupComponent
-            key={group.title}
-            group={group}
-            userInput={userInput[group.title] || {}}
-            onConfigChange={handleConfigChange}
-          />
-        ))}
-      </div>
+        <div className="settings-actions">
+          <button className="secondary-button" type="button" onClick={settings.resetConfig} disabled={!settings.loaded || settings.saveStatus === 'saving'}>恢复默认值</button>
+          <div className={`save-status ${settings.saveStatus}`} role="status" aria-live="polite"><span className="status-dot" />{statusText}</div>
+        </div>
+      </header>
+      {settings.saveStatus === 'error' && (
+        <div className="save-error" role="alert">
+          <div><strong>配置尚未写入服务端</strong><span>{settings.saveError || '请确认服务正在运行后重试。本地修改已保留。'}</span></div>
+          <button type="button" onClick={() => void settings.saveConfig()}>重试保存</button>
+        </div>
+      )}
+      {!settings.loaded ? <div className="settings-loading" role="status">正在加载配置…</div> : (
+        <div className="settings-content">
+          {settings.uiConfig.map((group) => <ConfigGroupComponent key={group.title} group={group} userInput={settings.userInput[group.title] || {}} onConfigChange={settings.handleConfigChange} />)}
+        </div>
+      )}
     </div>
   );
 };
 
 export class ProjectSettingsProvider implements UIProvider {
-  getName(): string {
-    return 'project_settings';
-  }
-
-  getUI(path: string): JSX.Element {
-    return <ProjectSettings path={path} />;
-  }
+  getName(): string { return 'project_settings'; }
+  getUI(path: string): JSX.Element { return <ProjectSettings path={path} />; }
 }
 
 export default ProjectSettings;

--- a/frontend/functional_ui/src/ui/settings/settingsSchema.ts
+++ b/frontend/functional_ui/src/ui/settings/settingsSchema.ts
@@ -11,15 +11,18 @@ export const settingsSchema: ConfigGroup[] = [
     items: [
       {
         key: 'civitai_token',
-        name: "Civitai网站Token",
-        type: "string",
-        description: "Civitai网站的Token"
+        name: 'Civitai 访问令牌',
+        type: 'string',
+        description: '用于访问 Civitai API。令牌会保存在本机服务的配置文件中。',
+        placeholder: '输入 API Token',
+        sensitive: true
       },
       {
         key: 'external_code_editor',
-        name: "外部代码编辑器",
-        type: "string",
-        description: "外部代码编辑器路径"
+        name: '外部代码编辑器',
+        type: 'string',
+        description: '打开代码文件时优先使用的编辑器可执行文件路径。留空则使用系统默认应用。',
+        placeholder: '例如 C:\\Program Files\\Microsoft VS Code\\Code.exe'
       }
     ]
   },
@@ -31,7 +34,11 @@ export const settingsSchema: ConfigGroup[] = [
         name: '主题颜色',
         type: 'enum',
         description: '选择界面主题颜色：跟随系统 / 浅色 / 深色',
-        options: ['system', 'light', 'dark']
+        options: [
+          { value: 'system', label: '跟随系统' },
+          { value: 'light', label: '浅色' },
+          { value: 'dark', label: '深色' }
+        ]
       },
       {
         key: 'auto_open_details',

--- a/frontend/functional_ui/src/ui/settings/types.ts
+++ b/frontend/functional_ui/src/ui/settings/types.ts
@@ -8,8 +8,10 @@ export interface ConfigItem {
   name: string;
   type: ConfigType;
   description: string;
+  placeholder?: string;
+  sensitive?: boolean;
   value?: any;
-  options?: string[]; // 用于enum类型
+  options?: { value: string; label: string }[]; // 用于enum类型
   items?: { key: string; value: string }[]; // 用于dict类型
   listItems?: string[]; // 用于list类型
 }
@@ -37,5 +39,5 @@ export interface UserInputState {
 export interface ProjectSettingsState {
   uiConfig: ConfigGroup[];  // 界面配置
   userInput: UserInputState;  // 用户输入状态
-  saveStatus: 'saved' | 'saving' | 'unsaved';
-} 
+  saveStatus: 'saved' | 'saving' | 'unsaved' | 'error';
+}

--- a/frontend/functional_ui/src/ui/settings/useProjectSettings.ts
+++ b/frontend/functional_ui/src/ui/settings/useProjectSettings.ts
@@ -20,7 +20,15 @@ const buildUserInput = (config: UiConfig): UserInputState => {
 };
 
 export const useProjectSettings = (_path: string) => {
-  const { config, saveStatus, updateConfig } = useConfig();
+  const {
+    config,
+    loaded,
+    saveStatus,
+    saveError,
+    updateConfig,
+    saveConfig,
+    resetConfig,
+  } = useConfig();
 
   const userInput = useMemo(() => buildUserInput(config), [config]);
 
@@ -38,7 +46,11 @@ export const useProjectSettings = (_path: string) => {
   return {
     uiConfig: settingsSchema,
     userInput,
+    loaded,
     saveStatus,
-    handleConfigChange
+    saveError,
+    handleConfigChange,
+    saveConfig,
+    resetConfig,
   };
 };

--- a/server/config_service.py
+++ b/server/config_service.py
@@ -1,12 +1,16 @@
-import os
 import json
-from typing import Dict, Any, List, Tuple
-from server.models import Settings, UiSettings, ModelInfo
-from server.opener_service import FileOpenerManager
+import os
+import tempfile
+from threading import RLock
+from typing import Any, Dict, List
+
+from server.models import ModelInfo, Settings
+
 
 class ConfigService:
     def __init__(self, settings_path: str):
         self.settings_path = settings_path
+        self._lock = RLock()
         self.settings = self._load_settings()
     
     def _load_settings(self) -> Settings:
@@ -18,39 +22,78 @@ class ConfigService:
         with open(self.settings_path, "r", encoding="utf-8") as f:
             return Settings.model_validate_json(f.read())
     
+    def _write_settings(self, settings: Settings) -> None:
+        """原子写入配置，避免进程中断留下半截 JSON 文件。"""
+        settings_dir = os.path.dirname(os.path.abspath(self.settings_path))
+        os.makedirs(settings_dir, exist_ok=True)
+        temp_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=settings_dir,
+                prefix=".ssui_config_",
+                suffix=".tmp",
+                delete=False,
+            ) as temp_file:
+                temp_path = temp_file.name
+                json.dump(
+                    settings.model_dump(mode="json"),
+                    temp_file,
+                    indent=4,
+                    ensure_ascii=False,
+                )
+                temp_file.flush()
+                os.fsync(temp_file.fileno())
+            os.replace(temp_path, self.settings_path)
+        finally:
+            if temp_path and os.path.exists(temp_path):
+                os.unlink(temp_path)
+
     def save_settings(self) -> None:
-        if not os.path.exists(os.path.dirname(self.settings_path)):
-            os.makedirs(os.path.dirname(self.settings_path))
-        with open(self.settings_path, "w", encoding="utf-8") as f:
-            json.dump(self.settings.model_dump(), f, indent=4, ensure_ascii=False)
+        with self._lock:
+            self._write_settings(self.settings)
     
     def get_settings(self) -> Settings:
         return self.settings
 
     def get_config(self) -> Dict[str, Any]:
         """返回可序列化的完整配置（供前端读取）。"""
-        return self.settings.model_dump(mode="json")
+        with self._lock:
+            return self.settings.model_dump(mode="json")
 
-    def update_config(self, config: Dict[str, Any]) -> Dict[str, str]:
+    def update_config(self, config: Dict[str, Any]) -> Dict[str, Any]:
         if not isinstance(config, dict):
             raise ValueError("Config must be a JSON object")
 
-        updated = self.settings.model_copy(deep=True)
-        for key, value in config.items():
-            if key == "ui" and isinstance(value, dict):
-                merged = UiSettings.model_validate(
-                    {**updated.ui.model_dump(), **value}
-                )
-                updated = updated.model_copy(update={"ui": merged})
-            elif hasattr(updated, key):
-                updated = updated.model_copy(update={key: value})
-        self.settings = updated
-        self.save_settings()
-        return {"message": "Config updated"}
+        with self._lock:
+            current = self.settings.model_dump()
+            allowed_fields = set(Settings.model_fields)
+            for key, value in config.items():
+                if key not in allowed_fields:
+                    continue
+                if key == "ui":
+                    if not isinstance(value, dict):
+                        raise ValueError("ui must be a JSON object")
+                    current["ui"] = {
+                        **self.settings.ui.model_dump(),
+                        **value,
+                    }
+                else:
+                    current[key] = value
+
+            # 对整个结果重新校验，避免 model_copy(update=...) 绕过字段校验。
+            updated = Settings.model_validate(current)
+            self._write_settings(updated)
+            self.settings = updated
+            return self.settings.model_dump(mode="json")
     
     def get_installed_models(self) -> List[ModelInfo]:
         return self.settings.installed_models
     
     def add_installed_model(self, model: ModelInfo) -> None:
-        self.settings.installed_models.append(model)
-        self.save_settings() 
+        with self._lock:
+            updated = self.settings.model_copy(deep=True)
+            updated.installed_models.append(model)
+            self._write_settings(updated)
+            self.settings = updated

--- a/server/models.py
+++ b/server/models.py
@@ -25,10 +25,10 @@ class UiSettings(BaseModel):
 
 class Settings(BaseModel):
     host_web_ui: str
-    additional_model_dirs: List[str] = []
-    installed_models: List[ModelInfo] = []
+    additional_model_dirs: List[str] = Field(default_factory=list)
+    installed_models: List[ModelInfo] = Field(default_factory=list)
     resources_dir: Optional[str] = None
-    ui: UiSettings = UiSettings()
+    ui: UiSettings = Field(default_factory=UiSettings)
 
 class ScanModelsRequest(BaseModel):
     scan_dir: str = Field(description="The directory to scan for models")

--- a/server/routes/config_routes.py
+++ b/server/routes/config_routes.py
@@ -2,7 +2,7 @@ import os
 import uuid
 from typing import Any, Dict
 
-from fastapi import APIRouter, Body, Request
+from fastapi import APIRouter, Body, HTTPException, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from starlette.background import BackgroundTask
@@ -20,7 +20,10 @@ async def get_config(request: Request):
 
 @router.post("/config/")
 async def config(request: Request, config: Dict[str, Any]):
-    return request.app.state.config_service.update_config(config)
+    try:
+        return request.app.state.config_service.update_config(config)
+    except ValueError as error:
+        raise HTTPException(status_code=422, detail=str(error)) from error
 
 
 @router.post("/config/scan_models/{client_id}")

--- a/server/routes/model_routes.py
+++ b/server/routes/model_routes.py
@@ -65,16 +65,29 @@ async def hf_download(
 
 
 @router.get("/api/civitai/models")
-async def civitai_models(query: str = "", type: str = "", page: int = 1, limit: int = 50):
+async def civitai_models(
+    request: Request,
+    query: str = "",
+    type: str = "",
+    page: int = 1,
+    limit: int = 50,
+):
     """Civitai 模型搜索代理：避免浏览器端 CORS，服务端透传 Civitai API。"""
     params: dict = {"page": page, "limit": min(limit, 100)}
     if query:
         params["query"] = query
     if type:
         params["types"] = type
+    ui_config = request.app.state.config_service.get_config().get("ui", {})
+    token = ui_config.get("civitai_token", "").strip()
+    headers = {"Authorization": f"Bearer {token}"} if token else None
     try:
         async with httpx.AsyncClient(timeout=30) as client:
-            resp = await client.get("https://civitai.com/api/v1/models", params=params)
+            resp = await client.get(
+                "https://civitai.com/api/v1/models",
+                params=params,
+                headers=headers,
+            )
             if resp.status_code != 200:
                 return JSONResponse(
                     {"error": f"Civitai API error: {resp.status_code}"},

--- a/tests/civitai_config_test.py
+++ b/tests/civitai_config_test.py
@@ -1,0 +1,76 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from server.routes.model_routes import civitai_models
+
+
+class FakeResponse:
+    status_code = 200
+
+    def json(self):
+        return {"items": []}
+
+
+class FakeAsyncClient:
+    def __init__(self):
+        self.get_args = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def get(self, *args, **kwargs):
+        self.get_args = (args, kwargs)
+        return FakeResponse()
+
+
+class TestCivitaiConfig(unittest.IsolatedAsyncioTestCase):
+    async def test_configured_token_is_forwarded(self):
+        config_service = MagicMock()
+        config_service.get_config.return_value = {
+            "ui": {"civitai_token": "secret-token"}
+        }
+        request = SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(config_service=config_service)
+            )
+        )
+        client = FakeAsyncClient()
+
+        with patch(
+            "server.routes.model_routes.httpx.AsyncClient",
+            return_value=client,
+        ):
+            result = await civitai_models(request, query="flux")
+
+        self.assertEqual(result, {"items": []})
+        self.assertEqual(
+            client.get_args[1]["headers"],
+            {"Authorization": "Bearer secret-token"},
+        )
+        self.assertEqual(client.get_args[1]["params"]["query"], "flux")
+
+    async def test_empty_token_does_not_add_authorization_header(self):
+        config_service = MagicMock()
+        config_service.get_config.return_value = {"ui": {"civitai_token": ""}}
+        request = SimpleNamespace(
+            app=SimpleNamespace(
+                state=SimpleNamespace(config_service=config_service)
+            )
+        )
+        client = FakeAsyncClient()
+
+        with patch(
+            "server.routes.model_routes.httpx.AsyncClient",
+            return_value=client,
+        ):
+            await civitai_models(request)
+
+        self.assertIsNone(client.get_args[1]["headers"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/config_service_test.py
+++ b/tests/config_service_test.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from server.config_service import ConfigService
 
@@ -25,7 +26,8 @@ class TestConfigService(unittest.TestCase):
         result = self.service.update_config(
             {"ui": {"theme": "dark", "auto_open_details": False}}
         )
-        self.assertIn("message", result)
+        self.assertEqual(result["ui"]["theme"], "dark")
+        self.assertFalse(result["ui"]["auto_open_details"])
 
         settings = self.service.get_settings()
         self.assertEqual(settings.ui.theme, "dark")
@@ -48,12 +50,28 @@ class TestConfigService(unittest.TestCase):
         result = self.service.update_config(
             {"ui": {"theme": "dark"}, "not_a_setting": 42}
         )
-        self.assertIn("message", result)
+        self.assertNotIn("not_a_setting", result)
         self.assertEqual(self.service.get_settings().ui.theme, "dark")
 
     def test_update_invalid_theme_raises(self):
         with self.assertRaises(Exception):
             self.service.update_config({"ui": {"theme": "neon"}})
+
+    def test_update_invalid_ui_shape_raises(self):
+        with self.assertRaises(ValueError):
+            self.service.update_config({"ui": "dark"})
+
+    def test_failed_write_does_not_change_in_memory_settings(self):
+        with patch.object(self.service, "_write_settings", side_effect=OSError("disk full")):
+            with self.assertRaises(OSError):
+                self.service.update_config({"ui": {"theme": "dark"}})
+        self.assertEqual(self.service.get_settings().ui.theme, "system")
+
+    def test_settings_instances_do_not_share_mutable_defaults(self):
+        another_path = os.path.join(self.tmp_dir, "another_config.json")
+        another = ConfigService(another_path)
+        self.service.get_settings().additional_model_dirs.append("models")
+        self.assertEqual(another.get_settings().additional_model_dirs, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要
- 重构通用配置页面，补齐加载、自动保存、失败重试和恢复默认值状态
- 修复连续修改的保存竞态，并在自动保存前同步保留本地缓存
- 服务端配置改为完整校验、线程保护和原子写盘
- 将 Civitai Token 作为敏感配置并接入服务端 API 请求
- 修复 Pydantic 可变默认值并为非法配置返回 422

## 测试
- 配置服务单元测试：9 项通过
- Civitai 配置接入测试：2 项通过
- 配置 API 路由测试：通过
- git diff --check：通过

## 已知验证限制
- Functional UI 完整构建仍被仓库现有依赖状态阻塞：缺少 monaco-editor，且当前 ssui_components 未导出 ContextMenu / ContextMenuItem；本次修改文件未出现 TypeScript 报错。